### PR TITLE
Do some rename for a cleaner API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-JSON streaming parser
-=================
+JSON streaming parser and serializer
+====================================
 
 [![actions status](https://github.com/oxigraph/json-event-parser/workflows/build/badge.svg)](https://github.com/oxigraph/json-event-parser/actions)
 [![Latest Version](https://img.shields.io/crates/v/json-event-parser.svg)](https://crates.io/crates/json-event-parser)
@@ -7,53 +7,55 @@ JSON streaming parser
 
 JSON event parser is a simple streaming JSON parser and serializer implementation in Rust.
 
-It does not aims to be the fastest JSON parser possible but to be a simple implementation.
+It does not aims to be the fastest JSON parser possible but to be a simple implementation allowing to parse larger than
+memory files.
 
-If you want fast and battle-tested code you might prefer to use [json](https://crates.io/crates/json), [serde_json](https://crates.io/crates/serde_json) or [simd-json](https://crates.io/crates/simd-json).
+If you want fast and battle-tested code you might prefer to
+use [json](https://crates.io/crates/json), [serde_json](https://crates.io/crates/serde_json)
+or [simd-json](https://crates.io/crates/simd-json).
 
-Reader example:
+Parser example:
 
 ```rust
-use json_event_parser::{FromReadJsonReader, JsonEvent};
+use json_event_parser::{ReaderJsonParser, JsonEvent};
 
 let json = b"{\"foo\": 1}";
-let mut reader = FromReadJsonReader::new(json.as_slice());
-assert_eq!(reader.read_next_event()?, JsonEvent::StartObject);
-assert_eq!(reader.read_next_event()?, JsonEvent::ObjectKey("foo".into()));
-assert_eq!(reader.read_next_event()?, JsonEvent::Number("1".into()));
-assert_eq!(reader.read_next_event()?, JsonEvent::EndObject);
-assert_eq!(reader.read_next_event()?, JsonEvent::Eof);
+let mut reader = ReaderJsonParser::new(json.as_slice());
+assert_eq!(reader.parse_next()?, JsonEvent::StartObject);
+assert_eq!(reader.parse_next()?, JsonEvent::ObjectKey("foo".into()));
+assert_eq!(reader.parse_next()?, JsonEvent::Number("1".into()));
+assert_eq!(reader.parse_next()?, JsonEvent::EndObject);
+assert_eq!(reader.parse_next()?, JsonEvent::Eof);
 # std::io::Result::Ok(())
 ```
 
-Writer example:
+Serializer example:
 
 ```rust
-use json_event_parser::{ToWriteJsonWriter, JsonEvent};
+use json_event_parser::{WriterJsonSerializer, JsonEvent};
 
-let mut writer = ToWriteJsonWriter::new(Vec::new());
-writer.write_event(JsonEvent::StartObject)?;
-writer.write_event(JsonEvent::ObjectKey("foo".into()))?;
-writer.write_event(JsonEvent::Number("1".into()))?;
-writer.write_event(JsonEvent::EndObject)?;
+let mut writer = WriterJsonSerializer::new(Vec::new());
+writer.write_event(JsonEvent::StartObject) ?;
+writer.write_event(JsonEvent::ObjectKey("foo".into())) ?;
+writer.write_event(JsonEvent::Number("1".into())) ?;
+writer.write_event(JsonEvent::EndObject) ?;
 
 assert_eq!(writer.finish()?.as_slice(), b"{\"foo\":1}");
 # std::io::Result::Ok(())
 ```
 
-
 ## License
 
 This project is licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
-   `<http://www.apache.org/licenses/LICENSE-2.0>`)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or
-   `<http://opensource.org/licenses/MIT>`)
-   
-at your option.
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+  `<http://www.apache.org/licenses/LICENSE-2.0>`)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or
+  `<http://opensource.org/licenses/MIT>`)
 
+at your option.
 
 ### Contribution
 
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in json-event-parser by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in json-event-parser by
+you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -1,5 +1,5 @@
 use codspeed_criterion_compat::{criterion_group, criterion_main, Criterion};
-use json_event_parser::{FromReadJsonReader, JsonEvent};
+use json_event_parser::{JsonEvent, ReaderJsonParser};
 use std::fs::{self, read_dir};
 
 fn bench_parse_json_benchmark(c: &mut Criterion) {
@@ -11,9 +11,9 @@ fn bench_parse_json_benchmark(c: &mut Criterion) {
         .unwrap();
         c.bench_function(dataset, |b| {
             b.iter(|| {
-                let mut reader = FromReadJsonReader::new(data.as_slice());
-                while reader.read_next_event().unwrap() != JsonEvent::Eof {
-                    //read more
+                let mut reader = ReaderJsonParser::new(data.as_slice());
+                while reader.parse_next().unwrap() != JsonEvent::Eof {
+                    // read more
                 }
             })
         });
@@ -25,9 +25,9 @@ fn bench_parse_testsuite(c: &mut Criterion) {
 
     c.bench_function("JSON test suite", |b| {
         b.iter(|| {
-            let mut reader = FromReadJsonReader::new(example.as_slice());
-            while reader.read_next_event().unwrap() != JsonEvent::Eof {
-                //read more
+            let mut reader = ReaderJsonParser::new(example.as_slice());
+            while reader.parse_next().unwrap() != JsonEvent::Eof {
+                // read more
             }
         })
     });

--- a/fuzz/fuzz_targets/parse.rs
+++ b/fuzz/fuzz_targets/parse.rs
@@ -18,7 +18,7 @@ fn parse_chunks(chunks: &[&[u8]]) -> (String, Option<SyntaxError>) {
             let LowLevelJsonReaderResult {
                 event,
                 consumed_bytes,
-            } = reader.read_next_event(&input_buffer[input_cursor..], i == chunks.len() - 1);
+            } = reader.parse_next(&input_buffer[input_cursor..], i == chunks.len() - 1);
             input_cursor += consumed_bytes;
             match event {
                 Some(Ok(JsonEvent::Eof)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,14 +15,14 @@ mod read;
 mod write;
 
 #[cfg(feature = "async-tokio")]
-pub use crate::read::FromTokioAsyncReadJsonReader;
+pub use crate::read::TokioAsyncReaderJsonParser;
 pub use crate::read::{
-    FromBufferJsonReader, FromReadJsonReader, LowLevelJsonReader, LowLevelJsonReaderResult,
-    ParseError, SyntaxError, TextPosition,
+    JsonParseError, JsonSyntaxError, LowLevelJsonParser, LowLevelJsonParserResult,
+    ReaderJsonParser, SliceJsonParser, TextPosition,
 };
 #[cfg(feature = "async-tokio")]
-pub use crate::write::ToTokioAsyncWriteJsonWriter;
-pub use crate::write::{LowLevelJsonWriter, ToWriteJsonWriter};
+pub use crate::write::TokioAsyncWriterJsonSerializer;
+pub use crate::write::{LowLevelJsonSerializer, WriterJsonSerializer};
 use std::borrow::Cow;
 
 /// Possible events during JSON parsing.
@@ -39,3 +39,26 @@ pub enum JsonEvent<'a> {
     ObjectKey(Cow<'a, str>),
     Eof,
 }
+
+#[cfg(feature = "async-tokio")]
+#[deprecated(note = "Use TokioAsyncReaderJsonParser")]
+pub type FromTokioAsyncReadJsonReader<R> = TokioAsyncReaderJsonParser<R>;
+#[deprecated(note = "Use SliceJsonParser")]
+pub type FromBufferJsonReader<'a> = SliceJsonParser<'a>;
+#[deprecated(note = "Use ReaderJsonParser")]
+pub type FromReadJsonReader<R> = ReaderJsonParser<R>;
+#[deprecated(note = "Use LowLevelJsonParser")]
+pub type LowLevelJsonReader = LowLevelJsonParser;
+#[deprecated(note = "Use LowLevelJsonParserResult")]
+pub type LowLevelJsonReaderResult<'a> = LowLevelJsonParserResult<'a>;
+#[deprecated(note = "Use JsonParseError")]
+pub type ParseError = JsonParseError;
+#[deprecated(note = "Use JsonSyntaxError")]
+pub type SyntaxError = JsonSyntaxError;
+#[cfg(feature = "async-tokio")]
+#[deprecated(note = "Use TokioAsyncWriterJsonSerializer")]
+pub type ToTokioAsyncWriteJsonWriter<W> = TokioAsyncWriterJsonSerializer<W>;
+#[deprecated(note = "Use WriterJsonSerializer")]
+pub type ToWriteJsonWriter<W> = WriterJsonSerializer<W>;
+#[deprecated(note = "Use LowLevelJsonSerializer")]
+pub type LowLevelJsonWriter = LowLevelJsonSerializer;

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,4 +1,4 @@
-use json_event_parser::{FromBufferJsonReader, JsonEvent, ToWriteJsonWriter};
+use json_event_parser::{JsonEvent, SliceJsonParser, WriterJsonSerializer};
 
 #[test]
 fn test_recovery() {
@@ -14,10 +14,10 @@ fn test_recovery() {
     ];
 
     for (input, expected_output) in entries {
-        let mut reader = FromBufferJsonReader::new(input);
-        let mut writer = ToWriteJsonWriter::new(Vec::new());
+        let mut reader = SliceJsonParser::new(input);
+        let mut writer = WriterJsonSerializer::new(Vec::new());
         loop {
-            match reader.read_next_event() {
+            match reader.parse_next() {
                 Ok(JsonEvent::Eof) => break,
                 Ok(event) => writer.write_event(event).unwrap(),
                 Err(_) => (),
@@ -59,8 +59,8 @@ fn test_error_messages() {
     ];
     for (json, error) in entries {
         assert_eq!(
-            FromBufferJsonReader::new(json)
-                .read_next_event()
+            SliceJsonParser::new(json)
+                .parse_next()
                 .unwrap_err()
                 .to_string(),
             error

--- a/tests/test_suite.rs
+++ b/tests/test_suite.rs
@@ -1,4 +1,4 @@
-use json_event_parser::{FromBufferJsonReader, FromReadJsonReader, JsonEvent, ToWriteJsonWriter};
+use json_event_parser::{JsonEvent, ReaderJsonParser, SliceJsonParser, WriterJsonSerializer};
 use std::fs::{read_dir, File};
 use std::io::{Read, Result};
 use std::{fs, str};
@@ -93,10 +93,10 @@ fn test_testsuite_parsing() -> Result<()> {
 }
 
 fn parse_buffer_result(read: &[u8]) -> Result<Vec<u8>> {
-    let mut reader = FromBufferJsonReader::new(read);
-    let mut writer = ToWriteJsonWriter::new(Vec::new());
+    let mut reader = SliceJsonParser::new(read);
+    let mut writer = WriterJsonSerializer::new(Vec::new());
     loop {
-        match reader.read_next_event()? {
+        match reader.parse_next()? {
             JsonEvent::Eof => return writer.finish(),
             e => writer.write_event(e)?,
         }
@@ -104,10 +104,10 @@ fn parse_buffer_result(read: &[u8]) -> Result<Vec<u8>> {
 }
 
 fn parse_read_result(read: impl Read) -> Result<Vec<u8>> {
-    let mut reader = FromReadJsonReader::new(read);
-    let mut writer = ToWriteJsonWriter::new(Vec::new());
+    let mut reader = ReaderJsonParser::new(read);
+    let mut writer = WriterJsonSerializer::new(Vec::new());
     loop {
-        match reader.read_next_event()? {
+        match reader.parse_next()? {
             JsonEvent::Eof => return writer.finish(),
             e => writer.write_event(e)?,
         }


### PR DESCRIPTION
Aligns with the naming of Oxigraph parsers and serializers