### PR TITLE
incorrect error message on ObjectColon

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -472,7 +472,7 @@ impl LowLevelJsonParser {
                     (None, None)
                 } else {
                     let (event, _) = self.apply_new_token(token);
-                    (event, Some("Object keys must be strings".into()))
+                    (event, Some("Object keys must be followed by a colon ':'".into()))
                 }
             }
             Some(JsonState::ObjectValue) => {


### PR DESCRIPTION
ObjectColon error message seems mistakenly copy-pasted from ObjectKey directly above it. Provided sample error message.