### PR TITLE
Feat skipper and serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,10 @@ exclude = ["JSONTestSuite"]
 
 [features]
 async-tokio = ["dep:tokio"]
-serde = ["dep:serde", "dep:serde_json"]
+serde = ["dep:serde"]
 
 [dependencies]
 serde = { version = "1", optional = true }
-serde_json = { version = "1", optional = true }
 tokio = { version = "1.29", optional = true, features = ["io-util"] }
 
 [dev-dependencies]
@@ -29,6 +28,7 @@ codspeed-criterion-compat = ">=4,<6"
 tokio = { version = "1.29", features = ["rt", "macros"] }
 clap = "4"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [[bench]]
 name = "parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,18 @@ exclude = ["JSONTestSuite"]
 
 [features]
 async-tokio = ["dep:tokio"]
+serde = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
+serde = { version = "1", optional = true }
+serde_json = { version = "1", optional = true }
 tokio = { version = "1.29", optional = true, features = ["io-util"] }
 
 [dev-dependencies]
 codspeed-criterion-compat = ">=4,<6"
 tokio = { version = "1.29", features = ["rt", "macros"] }
 clap = "4"
+serde = { version = "1", features = ["derive"] }
 
 [[bench]]
 name = "parser"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@
 )]
 
 mod read;
+#[cfg(feature = "serde")]
+mod serde;
 mod skipper;
 mod write;
 
@@ -21,7 +23,9 @@ pub use crate::read::{
     JsonParseError, JsonSyntaxError, LowLevelJsonParser, LowLevelJsonParserResult,
     ReaderJsonParser, SliceJsonParser, TextPosition,
 };
-pub use crate::skipper::{Skipper, SkipError};
+#[cfg(feature = "serde")]
+pub use crate::serde::{JsonValueSink, JsonValueSource, SerDeIoError};
+pub use crate::skipper::{SkipError, Skipper};
 #[cfg(feature = "async-tokio")]
 pub use crate::write::TokioAsyncWriterJsonSerializer;
 pub use crate::write::{LowLevelJsonSerializer, WriterJsonSerializer};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 )]
 
 mod read;
+mod skipper;
 mod write;
 
 #[cfg(feature = "async-tokio")]
@@ -20,6 +21,7 @@ pub use crate::read::{
     JsonParseError, JsonSyntaxError, LowLevelJsonParser, LowLevelJsonParserResult,
     ReaderJsonParser, SliceJsonParser, TextPosition,
 };
+pub use crate::skipper::{Skipper, SkipError};
 #[cfg(feature = "async-tokio")]
 pub use crate::write::TokioAsyncWriterJsonSerializer;
 pub use crate::write::{LowLevelJsonSerializer, WriterJsonSerializer};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,11 +20,11 @@ mod write;
 #[cfg(feature = "async-tokio")]
 pub use crate::read::TokioAsyncReaderJsonParser;
 pub use crate::read::{
-    JsonParseError, JsonSyntaxError, LowLevelJsonParser, LowLevelJsonParserResult,
+    owned_event, JsonParseError, JsonSyntaxError, LowLevelJsonParser, LowLevelJsonParserResult,
     ReaderJsonParser, SliceJsonParser, TextPosition,
 };
 #[cfg(feature = "serde")]
-pub use crate::serde::{JsonValueSink, JsonValueSource, JsonEventSource, SerDeIoError};
+pub use crate::serde::{JsonEventSource, JsonValueSink, JsonValueSource, SerDeIoError};
 pub use crate::skipper::{SkipError, Skipper};
 #[cfg(feature = "async-tokio")]
 pub use crate::write::TokioAsyncWriterJsonSerializer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use crate::read::{
     ReaderJsonParser, SliceJsonParser, TextPosition,
 };
 #[cfg(feature = "serde")]
-pub use crate::serde::{JsonValueSink, JsonValueSource, SerDeIoError};
+pub use crate::serde::{JsonValueSink, JsonValueSource, JsonEventSource, SerDeIoError};
 pub use crate::skipper::{SkipError, Skipper};
 #[cfg(feature = "async-tokio")]
 pub use crate::write::TokioAsyncWriterJsonSerializer;

--- a/src/read.rs
+++ b/src/read.rs
@@ -1203,7 +1203,7 @@ fn read_digits(input_buffer: &[u8], is_ending: bool) -> Option<usize> {
 }
 
 #[inline]
-fn owned_event(event: JsonEvent<'_>) -> JsonEvent<'static> {
+pub(crate) fn owned_event(event: JsonEvent<'_>) -> JsonEvent<'static> {
     match event {
         JsonEvent::String(s) => JsonEvent::String(s.into_owned().into()),
         JsonEvent::Number(n) => JsonEvent::Number(n.into_owned().into()),

--- a/src/read.rs
+++ b/src/read.rs
@@ -1203,7 +1203,7 @@ fn read_digits(input_buffer: &[u8], is_ending: bool) -> Option<usize> {
 }
 
 #[inline]
-pub(crate) fn owned_event(event: JsonEvent<'_>) -> JsonEvent<'static> {
+pub fn owned_event(event: JsonEvent<'_>) -> JsonEvent<'static> {
     match event {
         JsonEvent::String(s) => JsonEvent::String(s.into_owned().into()),
         JsonEvent::Number(n) => JsonEvent::Number(n.into_owned().into()),

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,997 @@
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+pub use de::JsonValueSource;
+pub use ser::JsonValueSink;
+use serde::{de::Error as DeError, ser::Error as SerError};
+
+#[derive(Debug)]
+pub struct SerDeIoError(pub std::io::Error);
+
+impl SerDeIoError {
+    pub fn new<E>(kind: std::io::ErrorKind, msg: E) -> Self
+    where
+        E: Into<Box<dyn Error + Send + Sync>>,
+    {
+        Self(std::io::Error::new(kind, msg.into()))
+    }
+
+    pub fn custom<E>(msg: E) -> Self
+    where
+        E: Into<Box<dyn Error + Send + Sync>>,
+    {
+        Self::new(std::io::ErrorKind::Other, msg)
+    }
+}
+
+impl From<std::io::Error> for SerDeIoError {
+    #[inline]
+    fn from(e: std::io::Error) -> Self {
+        Self(e)
+    }
+}
+
+impl Display for SerDeIoError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SerIoError({})", self.0)
+    }
+}
+
+impl Error for SerDeIoError {
+    #[inline]
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl SerError for SerDeIoError {
+    #[inline]
+    fn custom<T>(msg: T) -> Self
+    where
+        T: Display,
+    {
+        Self::custom(msg.to_string())
+    }
+}
+
+impl DeError for SerDeIoError {
+    #[inline]
+    fn custom<T>(msg: T) -> Self
+    where
+        T: Display,
+    {
+        Self::custom(msg.to_string())
+    }
+}
+
+mod ser {
+    use super::SerDeIoError;
+    use crate::{JsonEvent, WriterJsonSerializer};
+    use serde::ser::{
+        SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
+        SerializeTupleStruct, SerializeTupleVariant,
+    };
+    use serde::{Serialize, Serializer};
+    use std::borrow::Cow;
+    use std::io::Write;
+
+    pub struct JsonValueSink<'a, W: Write> {
+        writer: &'a mut WriterJsonSerializer<W>,
+    }
+
+    impl<'a, W: Write> JsonValueSink<'a, W> {
+        pub fn new(writer: &'a mut WriterJsonSerializer<W>) -> Self {
+            Self { writer }
+        }
+    }
+
+    impl<'a, W: Write> Serializer for JsonValueSink<'a, W> {
+        type Ok = &'a mut WriterJsonSerializer<W>;
+        type Error = SerDeIoError;
+        type SerializeSeq = Self;
+        type SerializeTuple = Self;
+        type SerializeTupleStruct = Self;
+        type SerializeTupleVariant = Self;
+        type SerializeMap = Self;
+        type SerializeStruct = Self;
+        type SerializeStructVariant = Self;
+
+        fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+            self.writer.serialize_event(JsonEvent::Boolean(v))?;
+            Ok(self.writer)
+        }
+
+        fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+            self.writer
+                .serialize_event(JsonEvent::Number(Cow::Owned(v.to_string())))?;
+            Ok(self.writer)
+        }
+
+        fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+            self.writer
+                .serialize_event(JsonEvent::Number(Cow::Owned(v.to_string())))?;
+            Ok(self.writer)
+        }
+
+        fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+            self.writer
+                .serialize_event(JsonEvent::Number(Cow::Owned(v.to_string())))?;
+            Ok(self.writer)
+        }
+
+        fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+            self.writer
+                .serialize_event(JsonEvent::Number(Cow::Owned(v.to_string())))?;
+            Ok(self.writer)
+        }
+
+        fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+            self.writer
+                .serialize_event(JsonEvent::Number(Cow::Owned(v.to_string())))?;
+            Ok(self.writer)
+        }
+
+        fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+            self.writer
+                .serialize_event(JsonEvent::Number(Cow::Owned(v.to_string())))?;
+            Ok(self.writer)
+        }
+
+        fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+            self.writer
+                .serialize_event(JsonEvent::Number(Cow::Owned(v.to_string())))?;
+            Ok(self.writer)
+        }
+
+        fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+            self.writer
+                .serialize_event(JsonEvent::Number(Cow::Owned(v.to_string())))?;
+            Ok(self.writer)
+        }
+
+        fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+            self.writer
+                .serialize_event(JsonEvent::Number(Cow::Owned(v.to_string())))?;
+            Ok(self.writer)
+        }
+
+        fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+            self.writer
+                .serialize_event(JsonEvent::Number(Cow::Owned(v.to_string())))?;
+            Ok(self.writer)
+        }
+
+        fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+            self.writer
+                .serialize_event(JsonEvent::String(Cow::Owned(v.to_string())))?;
+            Ok(self.writer)
+        }
+
+        fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+            self.writer
+                .serialize_event(JsonEvent::String(Cow::Borrowed(v)))?;
+            Ok(self.writer)
+        }
+
+        fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+            self.writer.serialize_event(JsonEvent::StartArray)?;
+            self.writer.serialize_event(JsonEvent::EndArray)?;
+            for b in v {
+                self.writer
+                    .serialize_event(JsonEvent::Number(Cow::Owned(b.to_string())))?;
+            }
+            Ok(self.writer)
+        }
+
+        fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+            self.writer.serialize_event(JsonEvent::Null)?;
+            Ok(self.writer)
+        }
+
+        fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+        where
+            T: ?Sized + Serialize,
+        {
+            value.serialize(self)
+        }
+
+        fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+            self.writer.serialize_event(JsonEvent::Null)?;
+            Ok(self.writer)
+        }
+
+        fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+            self.serialize_unit()
+        }
+
+        fn serialize_unit_variant(
+            self,
+            _name: &'static str,
+            _variant_index: u32,
+            variant: &'static str,
+        ) -> Result<Self::Ok, Self::Error> {
+            self.serialize_str(variant)
+        }
+
+        fn serialize_newtype_struct<T>(
+            self,
+            _name: &'static str,
+            value: &T,
+        ) -> Result<Self::Ok, Self::Error>
+        where
+            T: ?Sized + Serialize,
+        {
+            value.serialize(self)
+        }
+
+        fn serialize_newtype_variant<T>(
+            self,
+            _name: &'static str,
+            _variant_index: u32,
+            variant: &'static str,
+            value: &T,
+        ) -> Result<Self::Ok, Self::Error>
+        where
+            T: ?Sized + Serialize,
+        {
+            let writer = self.writer;
+            writer.serialize_event(JsonEvent::StartObject)?;
+            writer.serialize_event(JsonEvent::ObjectKey(Cow::Borrowed(variant)))?;
+            let writer = value.serialize(Self::new(writer))?;
+            writer.serialize_event(JsonEvent::EndObject)?;
+            Ok(writer)
+        }
+
+        fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+            self.writer.serialize_event(JsonEvent::StartArray)?;
+            Ok(self)
+        }
+
+        fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+            self.writer.serialize_event(JsonEvent::StartArray)?;
+            Ok(self)
+        }
+
+        fn serialize_tuple_struct(
+            self,
+            _name: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+            self.writer.serialize_event(JsonEvent::StartArray)?;
+            Ok(self)
+        }
+
+        fn serialize_tuple_variant(
+            self,
+            _name: &'static str,
+            _variant_index: u32,
+            variant: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+            self.writer.serialize_event(JsonEvent::StartObject)?;
+            self.writer
+                .serialize_event(JsonEvent::ObjectKey(Cow::Borrowed(variant)))?;
+            self.writer.serialize_event(JsonEvent::StartArray)?;
+            Ok(self)
+        }
+
+        fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+            self.writer.serialize_event(JsonEvent::StartObject)?;
+            Ok(self)
+        }
+
+        fn serialize_struct(
+            self,
+            _name: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeStruct, Self::Error> {
+            self.writer.serialize_event(JsonEvent::StartObject)?;
+            Ok(self)
+        }
+
+        fn serialize_struct_variant(
+            self,
+            _name: &'static str,
+            _variant_index: u32,
+            variant: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeStructVariant, Self::Error> {
+            self.writer.serialize_event(JsonEvent::StartObject)?;
+            self.writer
+                .serialize_event(JsonEvent::ObjectKey(Cow::Borrowed(variant)))?;
+            self.writer.serialize_event(JsonEvent::StartObject)?;
+            Ok(self)
+        }
+    }
+
+    macro_rules! imp_ser {
+        ($t:ty, $name:ident, $($end:expr),+) => {
+            impl<'a, W: Write> $t for JsonValueSink<'a, W> {
+                type Ok = &'a mut WriterJsonSerializer<W>;
+                type Error = SerDeIoError;
+
+                fn $name<T>(&mut self, value: &T) -> Result<(), Self::Error>
+                where
+                    T: ?Sized + Serialize,
+                {
+                    value.serialize(JsonValueSink::new(self.writer))?;
+                    Ok(())
+                }
+
+                fn end(self) -> Result<Self::Ok, Self::Error> {
+                    $(self.writer.serialize_event($end)?;)+
+                    Ok(self.writer)
+                }
+            }
+        };
+    }
+
+    imp_ser!(SerializeSeq, serialize_element, JsonEvent::EndArray);
+    imp_ser!(SerializeTuple, serialize_element, JsonEvent::EndArray);
+    imp_ser!(SerializeTupleStruct, serialize_field, JsonEvent::EndArray);
+    imp_ser!(
+        SerializeTupleVariant,
+        serialize_field,
+        JsonEvent::EndArray,
+        JsonEvent::EndObject
+    );
+
+    impl<'a, W: Write> SerializeMap for JsonValueSink<'a, W> {
+        type Ok = &'a mut WriterJsonSerializer<W>;
+        type Error = SerDeIoError;
+
+        fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
+        where
+            T: ?Sized + Serialize,
+        {
+            let key = serde_json::to_string(key).map_err(|err| {
+                SerDeIoError::custom(format!("convert key to value error: {:#?}", err))
+            })?;
+            self.writer
+                .serialize_event(JsonEvent::ObjectKey(Cow::Owned(key)))?;
+            Ok(())
+        }
+
+        fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
+        where
+            T: ?Sized + Serialize,
+        {
+            value.serialize(JsonValueSink::new(self.writer))?;
+            Ok(())
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            self.writer.serialize_event(JsonEvent::EndObject)?;
+            Ok(self.writer)
+        }
+    }
+
+    macro_rules! imp_ser_kv {
+        ($t:ty, $($end:expr),+) => {
+            impl<'a, W: Write> $t for JsonValueSink<'a, W> {
+                type Ok = &'a mut WriterJsonSerializer<W>;
+                type Error = SerDeIoError;
+
+                fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+                where
+                    T: ?Sized + Serialize,
+                {
+                    self.writer
+                        .serialize_event(JsonEvent::ObjectKey(Cow::Borrowed(key)))?;
+                    value.serialize(JsonValueSink::new(self.writer))?;
+                    Ok(())
+                }
+
+                fn end(self) -> Result<Self::Ok, Self::Error> {
+                    $(self.writer.serialize_event($end)?;)+
+                    Ok(self.writer)
+                }
+            }
+        };
+    }
+
+    imp_ser_kv!(SerializeStruct, JsonEvent::EndObject);
+    imp_ser_kv!(
+        SerializeStructVariant,
+        JsonEvent::EndObject,
+        JsonEvent::EndObject
+    );
+}
+
+mod de {
+    use crate::serde::SerDeIoError;
+    use crate::{JsonEvent, ReaderJsonParser, Skipper};
+    use serde::de::value::StrDeserializer;
+    use serde::de::{DeserializeSeed, EnumAccess, MapAccess, SeqAccess, VariantAccess, Visitor};
+    use serde::{Deserialize, Deserializer};
+    use std::borrow::{Borrow, Cow};
+    use std::fmt::{Display, Formatter};
+    use std::io::Read;
+    use std::marker::PhantomData;
+    use std::num::IntErrorKind;
+    use std::str::FromStr;
+
+    pub struct JsonValueSource<'a, R: Read> {
+        reader: &'a mut ReaderJsonParser<R>,
+        peek: Option<JsonEvent<'static>>,
+    }
+
+    impl<'a, R: Read> JsonValueSource<'a, R> {
+        pub fn new(reader: &'a mut ReaderJsonParser<R>) -> Self {
+            Self { reader, peek: None }
+        }
+
+        fn with_peek(self, event: JsonEvent<'static>) -> Self {
+            Self {
+                reader: self.reader,
+                peek: Some(event),
+            }
+        }
+
+        fn with_opt_peek(self, event: Option<JsonEvent<'static>>) -> Self {
+            if let Some(event) = event {
+                self.with_peek(event)
+            } else {
+                self
+            }
+        }
+
+        fn own_next_event(mut self) -> Result<JsonEvent<'a>, SerDeIoError> {
+            if let Some(event) = self.peek.take() {
+                return Ok(event);
+            }
+
+            self.reader
+                .parse_next()
+                .ok_or_else(|| SerDeIoError::new(std::io::ErrorKind::UnexpectedEof, "eof"))?
+                .map_err(SerDeIoError::custom)
+        }
+
+        fn next_event(&mut self) -> Result<JsonEvent<'_>, SerDeIoError> {
+            if let Some(event) = self.peek.take() {
+                return Ok(event);
+            }
+
+            self.reader
+                .parse_next()
+                .ok_or_else(|| SerDeIoError::new(std::io::ErrorKind::UnexpectedEof, "eof"))?
+                .map_err(SerDeIoError::custom)
+        }
+
+        fn next_event_static(&mut self) -> Result<JsonEvent<'static>, SerDeIoError> {
+            if let Some(event) = self.peek.take() {
+                return Ok(event);
+            }
+
+            self.next_event().map(event_to_static)
+        }
+
+        fn consume_byte_buf(&mut self, buf: &mut Vec<u8>) -> Result<(), SerDeIoError> {
+            loop {
+                match &self.next_event()? {
+                    JsonEvent::EndArray => {
+                        return Ok(());
+                    }
+                    JsonEvent::Number(text) => match text.parse::<u8>() {
+                        Ok(v) => buf.push(v),
+                        Err(err) => {
+                            return Err(SerDeIoError::custom(format!(
+                                "can't parse \"{}\" as byte while parsing bytes from array: {:#?}",
+                                text, err
+                            )))
+                        }
+                    },
+                    event => {
+                        return Err(SerDeIoError::custom(format!(
+                            "unexpect {} while parsing bytes from array",
+                            event_name(event)
+                        )))
+                    }
+                }
+            }
+        }
+    }
+
+    macro_rules! primitive_visit {
+        ($name:ident, $visit_fn:ident, $visit_ty:ty) => {
+            fn $name<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+            where
+                V: Visitor<'de>,
+            {
+                match &self.own_next_event()? {
+                    JsonEvent::String(v) => match v.parse::<$visit_ty>() {
+                        Ok(v) => visitor.$visit_fn(v),
+                        Err(_) => Err(unexpect_type("String", &visitor)),
+                    },
+                    JsonEvent::Number(v) => {
+                        visitor.$visit_fn(v.parse::<$visit_ty>().map_err(|err| {
+                            SerDeIoError::new(std::io::ErrorKind::InvalidInput, err)
+                        })?)
+                    }
+                    event => Err(unexpect_type(event_name(event), &visitor)),
+                }
+            }
+        };
+    }
+
+    impl<'a, 'de: 'a, R: Read> Deserializer<'de> for JsonValueSource<'a, R> {
+        type Error = SerDeIoError;
+
+        fn deserialize_any<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self.next_event_static()? {
+                JsonEvent::String(v) => visitor.visit_str(&v),
+                JsonEvent::Number(v) => {
+                    let num = v.parse::<JsonNumber>()?;
+                    num.visit(visitor)
+                }
+                JsonEvent::Boolean(v) => visitor.visit_bool(v),
+                JsonEvent::Null => visitor.visit_none(),
+                JsonEvent::StartArray => visitor.visit_seq(self),
+                JsonEvent::StartObject => visitor.visit_map(self),
+                event => Err(unexpect_type(event_name(&event), &visitor)),
+            }
+        }
+
+        primitive_visit!(deserialize_bool, visit_bool, bool);
+        primitive_visit!(deserialize_i8, visit_i8, i8);
+        primitive_visit!(deserialize_u8, visit_u8, u8);
+        primitive_visit!(deserialize_i16, visit_i16, i16);
+        primitive_visit!(deserialize_u16, visit_u16, u16);
+        primitive_visit!(deserialize_i32, visit_i32, i32);
+        primitive_visit!(deserialize_u32, visit_u32, u32);
+        primitive_visit!(deserialize_i64, visit_i64, i64);
+        primitive_visit!(deserialize_u64, visit_u64, u64);
+        primitive_visit!(deserialize_i128, visit_i128, i128);
+        primitive_visit!(deserialize_u128, visit_u128, u128);
+        primitive_visit!(deserialize_f32, visit_f32, f32);
+        primitive_visit!(deserialize_f64, visit_f64, f64);
+
+        fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self.own_next_event()? {
+                JsonEvent::String(v) => {
+                    let mut chars = v.chars();
+                    let ch = match chars.next() {
+                        Some(v) => v,
+                        None => return Err(unexpect_type("String(empty)", &visitor)),
+                    };
+                    if chars.next().is_some() {
+                        return Err(unexpect_type("String(multi chars)", &visitor));
+                    }
+                    visitor.visit_char(ch)
+                }
+                event => Err(unexpect_type(event_name(&event), &visitor)),
+            }
+        }
+
+        fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self.own_next_event()? {
+                JsonEvent::String(v) => visitor.visit_str(v.as_ref()),
+                event => Err(unexpect_type(event_name(&event), &visitor)),
+            }
+        }
+
+        fn deserialize_string<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self.next_event()? {
+                JsonEvent::String(v) => visitor.visit_string(v.into_owned()),
+                event => Err(unexpect_type(event_name(&event), &visitor)),
+            }
+        }
+
+        fn deserialize_bytes<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self.next_event()? {
+                JsonEvent::String(v) => visitor.visit_bytes(v.as_bytes()),
+                JsonEvent::StartArray => {
+                    let mut buf = Vec::<u8>::new();
+                    self.consume_byte_buf(&mut buf)?;
+                    visitor.visit_bytes(&buf)
+                }
+                event => Err(unexpect_type(event_name(&event), &visitor)),
+            }
+        }
+
+        fn deserialize_byte_buf<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            let mut buf = Vec::<u8>::new();
+            match self.next_event()? {
+                JsonEvent::String(v) => buf.extend_from_slice(v.as_bytes()),
+                JsonEvent::StartArray => {
+                    self.consume_byte_buf(&mut buf)?;
+                }
+                event => return Err(unexpect_type(event_name(&event), &visitor)),
+            }
+            visitor.visit_byte_buf(buf)
+        }
+
+        fn deserialize_option<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self.next_event_static()? {
+                JsonEvent::Null => visitor.visit_none(),
+                event => visitor.visit_some(self.with_peek(event)),
+            }
+        }
+
+        fn deserialize_unit<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            match &self.next_event()? {
+                JsonEvent::Null => visitor.visit_none(),
+                event => Err(unexpect_type(event_name(event), &visitor)),
+            }
+        }
+
+        fn deserialize_unit_struct<V>(
+            self,
+            _name: &'static str,
+            visitor: V,
+        ) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            self.deserialize_unit(visitor)
+        }
+
+        fn deserialize_newtype_struct<V>(
+            self,
+            _name: &'static str,
+            visitor: V,
+        ) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            visitor.visit_newtype_struct(self)
+        }
+
+        fn deserialize_seq<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self.next_event_static()? {
+                JsonEvent::StartArray => visitor.visit_seq(self),
+                event => Err(unexpect_type(event_name(&event), &visitor)),
+            }
+        }
+
+        fn deserialize_tuple<V>(mut self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self.next_event_static()? {
+                JsonEvent::StartArray => visitor.visit_seq(self),
+                event => Err(unexpect_type(event_name(&event), &visitor)),
+            }
+        }
+
+        fn deserialize_tuple_struct<V>(
+            mut self,
+            _name: &'static str,
+            _len: usize,
+            visitor: V,
+        ) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self.next_event_static()? {
+                JsonEvent::StartArray => visitor.visit_seq(self),
+                event => Err(unexpect_type(event_name(&event), &visitor)),
+            }
+        }
+
+        fn deserialize_map<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self.next_event()? {
+                JsonEvent::StartObject => visitor.visit_map(self),
+                event => Err(unexpect_type(event_name(&event), &visitor)),
+            }
+        }
+
+        fn deserialize_struct<V>(
+            mut self,
+            _name: &'static str,
+            _fields: &'static [&'static str],
+            visitor: V,
+        ) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self.next_event_static()? {
+                JsonEvent::StartArray => visitor.visit_seq(self),
+                JsonEvent::StartObject => visitor.visit_map(self),
+                event => Err(unexpect_type(event_name(&event), &visitor)),
+            }
+        }
+
+        fn deserialize_enum<V>(
+            mut self,
+            _name: &'static str,
+            _variants: &'static [&'static str],
+            visitor: V,
+        ) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            let event = self.next_event_static()?;
+            if matches!(event, JsonEvent::String(_) | JsonEvent::Number(_)) {
+                visitor.visit_enum(JsonVariantAccess {
+                    is_unit: true,
+                    peek: Some(event),
+                    source: self,
+                })
+            } else if matches!(event, JsonEvent::StartObject) {
+                visitor.visit_enum(JsonVariantAccess {
+                    is_unit: false,
+                    peek: Some(event),
+                    source: self,
+                })
+            } else {
+                Err(unexpect_type(event_name(&event), &visitor))
+            }
+        }
+
+        fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            self.deserialize_str(visitor)
+        }
+
+        fn deserialize_ignored_any<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            let mut skipper = Skipper::new();
+            while skipper.skipping() {
+                skipper
+                    .on_event(&self.next_event()?)
+                    .map_err(SerDeIoError::custom)?;
+            }
+            visitor.visit_unit()
+        }
+    }
+
+    struct JsonVariantAccess<'a, R: Read> {
+        is_unit: bool,
+        peek: Option<JsonEvent<'static>>,
+        source: JsonValueSource<'a, R>,
+    }
+
+    impl<'a, 'de: 'a, R: Read> EnumAccess<'de> for JsonVariantAccess<'a, R> {
+        type Error = SerDeIoError;
+        type Variant = Self;
+
+        fn variant_seed<V>(mut self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+        where
+            V: DeserializeSeed<'de>,
+        {
+            let peek = self.peek.take();
+            let val =
+                seed.deserialize(JsonValueSource::new(self.source.reader).with_opt_peek(peek))?;
+            Ok((val, self))
+        }
+    }
+
+    impl<'a, 'de: 'a, R: Read> VariantAccess<'de> for JsonVariantAccess<'a, R> {
+        type Error = SerDeIoError;
+
+        fn unit_variant(self) -> Result<(), Self::Error> {
+            if self.is_unit {
+                return Ok(());
+            }
+            Deserialize::deserialize(self.source)
+        }
+
+        fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+        where
+            T: DeserializeSeed<'de>,
+        {
+            if self.is_unit {
+                Err(SerDeIoError::custom(
+                    "UnitVariantAccess do **NOT** support newtype_variant_seed",
+                ))
+            } else {
+                seed.deserialize(self.source)
+            }
+        }
+
+        fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            if self.is_unit {
+                Err(SerDeIoError::custom(
+                    "UnitVariantAccess do **NOT** support tuple_variant",
+                ))
+            } else {
+                Deserializer::deserialize_seq(self.source, visitor)
+            }
+        }
+
+        fn struct_variant<V>(
+            self,
+            fields: &'static [&'static str],
+            visitor: V,
+        ) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            if self.is_unit {
+                Err(SerDeIoError::custom(
+                    "UnitVariantAccess do **NOT** support struct_variant",
+                ))
+            } else {
+                Deserializer::deserialize_struct(self.source, "", fields, visitor)
+            }
+        }
+    }
+
+    impl<'a, 'de: 'a, R: Read> MapAccess<'de> for JsonValueSource<'a, R> {
+        type Error = SerDeIoError;
+
+        fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+        where
+            K: DeserializeSeed<'de>,
+        {
+            let Some(event) = self.reader.parse_next() else {
+                return Err(SerDeIoError::new(std::io::ErrorKind::UnexpectedEof, "EOF"));
+            };
+            let event = event.map_err(SerDeIoError::custom)?;
+            match event {
+                JsonEvent::ObjectKey(k) => {
+                    seed.deserialize(StrDeserializer::new(k.as_ref())).map(Some)
+                }
+                JsonEvent::EndObject => Ok(None),
+                event => Err(SerDeIoError::custom(format!(
+                    "unexpect event for map key: {:#?}",
+                    event
+                ))),
+            }
+        }
+
+        fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+        where
+            V: DeserializeSeed<'de>,
+        {
+            seed.deserialize(JsonValueSource::new(self.reader))
+        }
+    }
+
+    impl<'a, 'de: 'a, R: Read> SeqAccess<'de> for JsonValueSource<'a, R> {
+        type Error = SerDeIoError;
+
+        fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+        where
+            T: DeserializeSeed<'de>,
+        {
+            match self.next_event_static()? {
+                JsonEvent::EndArray => Ok(None),
+                event => seed
+                    .deserialize(JsonValueSource::new(self.reader).with_peek(event))
+                    .map(Some),
+            }
+        }
+    }
+
+    enum JsonNumber {
+        I64(i64),
+        U64(u64),
+        F64(f64),
+    }
+
+    impl FromStr for JsonNumber {
+        type Err = SerDeIoError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            let s = s.trim();
+            let err = if s.starts_with('-') {
+                match s.parse::<i64>() {
+                    Ok(v) => return Ok(Self::I64(v)),
+                    Err(err) => err,
+                }
+            } else {
+                match s.parse::<u64>() {
+                    Ok(v) => return Ok(Self::U64(v)),
+                    Err(err) => err,
+                }
+            };
+
+            if matches!(
+                err.kind(),
+                IntErrorKind::NegOverflow | IntErrorKind::PosOverflow
+            ) {
+                match s.parse::<f64>() {
+                    Ok(v) => Ok(Self::F64(v)),
+                    Err(err) => Err(SerDeIoError::custom(format!("parse number error: {}", err))),
+                }
+            } else {
+                Err(SerDeIoError::custom(format!("parse number error: {}", err)))
+            }
+        }
+    }
+
+    impl JsonNumber {
+        fn visit<'de, V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerDeIoError> {
+            match self {
+                JsonNumber::I64(v) => visitor.visit_i64(v),
+                JsonNumber::U64(v) => visitor.visit_u64(v),
+                JsonNumber::F64(v) => visitor.visit_f64(v),
+            }
+        }
+    }
+
+    fn event_to_static<'a, V: Borrow<JsonEvent<'a>>>(event: V) -> JsonEvent<'static> {
+        match event.borrow() {
+            JsonEvent::String(v) => JsonEvent::String(Cow::Owned(v.to_string())),
+            JsonEvent::Number(v) => JsonEvent::Number(Cow::Owned(v.to_string())),
+            JsonEvent::Boolean(v) => JsonEvent::Boolean(*v),
+            JsonEvent::Null => JsonEvent::Null,
+            JsonEvent::StartArray => JsonEvent::StartArray,
+            JsonEvent::EndArray => JsonEvent::EndArray,
+            JsonEvent::StartObject => JsonEvent::StartObject,
+            JsonEvent::EndObject => JsonEvent::EndObject,
+            JsonEvent::ObjectKey(k) => JsonEvent::ObjectKey(Cow::Owned(k.to_string())),
+        }
+    }
+
+    fn event_name(event: &JsonEvent<'_>) -> &'static str {
+        match event {
+            JsonEvent::String(_) => "String",
+            JsonEvent::Number(_) => "Number",
+            JsonEvent::Boolean(_) => "Boolean",
+            JsonEvent::Null => "Null",
+            JsonEvent::StartArray => "StartArray",
+            JsonEvent::EndArray => "EndArray",
+            JsonEvent::StartObject => "StartObject",
+            JsonEvent::EndObject => "EndObject",
+            JsonEvent::ObjectKey(_) => "ObjectKey",
+        }
+    }
+
+    fn unexpect_type<'de, V: Visitor<'de>>(event_name: &str, visitor: &V) -> SerDeIoError {
+        struct ErrMeta<'a, 'de, V: Visitor<'de>> {
+            event_name: &'a str,
+            visitor: &'a V,
+            mark: PhantomData<&'de ()>,
+        }
+
+        impl<'a, 'de, V: Visitor<'de>> Display for ErrMeta<'a, 'de, V> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                write!(f, "UnexpectType[got={}, expect=", self.event_name)?;
+                self.visitor.expecting(f)?;
+                write!(f, "]")?;
+                Ok(())
+            }
+        }
+
+        SerDeIoError::new(
+            std::io::ErrorKind::InvalidInput,
+            ErrMeta {
+                event_name,
+                visitor,
+                mark: PhantomData,
+            }
+            .to_string(),
+        )
+    }
+}
+

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -344,9 +344,14 @@ mod ser {
         where
             T: ?Sized + Serialize,
         {
-            let key = serde_json::to_string(key).map_err(|err| {
-                SerDeIoError::custom(format!("convert key to value error: {:#?}", err))
-            })?;
+            let key = {
+                let mut key_buf = Vec::<u8>::new();
+                let mut key_json_writer = WriterJsonSerializer::new(&mut key_buf);
+                key.serialize(JsonValueSink::new(&mut key_json_writer))?;
+                String::from_utf8(key_buf)
+                    .map_err(|_| SerDeIoError::custom("can't encode json key to string"))?
+            };
+
             self.writer
                 .serialize_event(JsonEvent::ObjectKey(Cow::Owned(key)))?;
             Ok(())
@@ -994,4 +999,3 @@ mod de {
         )
     }
 }
-

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -787,7 +787,7 @@ mod de {
         where
             V: Visitor<'de>,
         {
-            let mut skipper = Skipper::<()>::default();
+            let mut skipper = Skipper::new();
             while skipper.skipping() {
                 skipper
                     .on_event(&self.next_event()?)

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,7 +1,9 @@
-use std::error::Error;
-use std::fmt::{Display, Formatter};
+use std::{
+    error::Error,
+    fmt::{Display, Formatter},
+};
 
-pub use de::JsonValueSource;
+pub use de::{JsonEventSource, JsonValueSource};
 pub use ser::JsonValueSink;
 use serde::{de::Error as DeError, ser::Error as SerError};
 
@@ -404,31 +406,51 @@ mod ser {
 }
 
 mod de {
+    use crate::read::owned_event;
     use crate::serde::SerDeIoError;
-    use crate::{JsonEvent, ReaderJsonParser, Skipper};
+    use crate::{JsonEvent, JsonParseError, ReaderJsonParser, Skipper};
     use serde::de::value::StrDeserializer;
     use serde::de::{DeserializeSeed, EnumAccess, MapAccess, SeqAccess, VariantAccess, Visitor};
     use serde::{Deserialize, Deserializer};
-    use std::borrow::{Borrow, Cow};
     use std::fmt::{Display, Formatter};
     use std::io::Read;
     use std::marker::PhantomData;
     use std::num::IntErrorKind;
     use std::str::FromStr;
 
-    pub struct JsonValueSource<'a, R: Read> {
-        reader: &'a mut ReaderJsonParser<R>,
+    pub trait JsonEventSource {
+        fn next_event(&mut self) -> Option<Result<JsonEvent<'_>, JsonParseError>>;
+    }
+
+    impl<R: Read> JsonEventSource for ReaderJsonParser<R> {
+        fn next_event(&mut self) -> Option<Result<JsonEvent<'_>, JsonParseError>> {
+            self.parse_next()
+        }
+    }
+
+    impl JsonEventSource for Vec<JsonEvent<'_>> {
+        fn next_event(&mut self) -> Option<Result<JsonEvent<'_>, JsonParseError>> {
+            if self.is_empty() {
+                None
+            } else {
+                Some(Ok(self.remove(0)))
+            }
+        }
+    }
+
+    pub struct JsonValueSource<'a, S: JsonEventSource> {
+        source: &'a mut S,
         peek: Option<JsonEvent<'static>>,
     }
 
-    impl<'a, R: Read> JsonValueSource<'a, R> {
-        pub fn new(reader: &'a mut ReaderJsonParser<R>) -> Self {
-            Self { reader, peek: None }
+    impl<'a, S: JsonEventSource> JsonValueSource<'a, S> {
+        pub fn new(source: &'a mut S) -> Self {
+            Self { source, peek: None }
         }
 
         fn with_peek(self, event: JsonEvent<'static>) -> Self {
             Self {
-                reader: self.reader,
+                source: self.source,
                 peek: Some(event),
             }
         }
@@ -446,8 +468,8 @@ mod de {
                 return Ok(event);
             }
 
-            self.reader
-                .parse_next()
+            self.source
+                .next_event()
                 .ok_or_else(|| SerDeIoError::new(std::io::ErrorKind::UnexpectedEof, "eof"))?
                 .map_err(SerDeIoError::custom)
         }
@@ -457,8 +479,8 @@ mod de {
                 return Ok(event);
             }
 
-            self.reader
-                .parse_next()
+            self.source
+                .next_event()
                 .ok_or_else(|| SerDeIoError::new(std::io::ErrorKind::UnexpectedEof, "eof"))?
                 .map_err(SerDeIoError::custom)
         }
@@ -468,7 +490,7 @@ mod de {
                 return Ok(event);
             }
 
-            self.next_event().map(event_to_static)
+            self.next_event().map(owned_event)
         }
 
         fn consume_byte_buf(&mut self, buf: &mut Vec<u8>) -> Result<(), SerDeIoError> {
@@ -519,7 +541,7 @@ mod de {
         };
     }
 
-    impl<'a, 'de: 'a, R: Read> Deserializer<'de> for JsonValueSource<'a, R> {
+    impl<'a, 'de: 'a, S: JsonEventSource> Deserializer<'de> for JsonValueSource<'a, S> {
         type Error = SerDeIoError;
 
         fn deserialize_any<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
@@ -765,7 +787,7 @@ mod de {
         where
             V: Visitor<'de>,
         {
-            let mut skipper = Skipper::new();
+            let mut skipper = Skipper::<()>::default();
             while skipper.skipping() {
                 skipper
                     .on_event(&self.next_event()?)
@@ -775,13 +797,13 @@ mod de {
         }
     }
 
-    struct JsonVariantAccess<'a, R: Read> {
+    struct JsonVariantAccess<'a, S: JsonEventSource> {
         is_unit: bool,
         peek: Option<JsonEvent<'static>>,
-        source: JsonValueSource<'a, R>,
+        source: JsonValueSource<'a, S>,
     }
 
-    impl<'a, 'de: 'a, R: Read> EnumAccess<'de> for JsonVariantAccess<'a, R> {
+    impl<'a, 'de: 'a, S: JsonEventSource> EnumAccess<'de> for JsonVariantAccess<'a, S> {
         type Error = SerDeIoError;
         type Variant = Self;
 
@@ -791,12 +813,12 @@ mod de {
         {
             let peek = self.peek.take();
             let val =
-                seed.deserialize(JsonValueSource::new(self.source.reader).with_opt_peek(peek))?;
+                seed.deserialize(JsonValueSource::new(self.source.source).with_opt_peek(peek))?;
             Ok((val, self))
         }
     }
 
-    impl<'a, 'de: 'a, R: Read> VariantAccess<'de> for JsonVariantAccess<'a, R> {
+    impl<'a, 'de: 'a, S: JsonEventSource> VariantAccess<'de> for JsonVariantAccess<'a, S> {
         type Error = SerDeIoError;
 
         fn unit_variant(self) -> Result<(), Self::Error> {
@@ -850,14 +872,14 @@ mod de {
         }
     }
 
-    impl<'a, 'de: 'a, R: Read> MapAccess<'de> for JsonValueSource<'a, R> {
+    impl<'a, 'de: 'a, S: JsonEventSource> MapAccess<'de> for JsonValueSource<'a, S> {
         type Error = SerDeIoError;
 
         fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
         where
             K: DeserializeSeed<'de>,
         {
-            let Some(event) = self.reader.parse_next() else {
+            let Some(event) = self.source.next_event() else {
                 return Err(SerDeIoError::new(std::io::ErrorKind::UnexpectedEof, "EOF"));
             };
             let event = event.map_err(SerDeIoError::custom)?;
@@ -877,11 +899,11 @@ mod de {
         where
             V: DeserializeSeed<'de>,
         {
-            seed.deserialize(JsonValueSource::new(self.reader))
+            seed.deserialize(JsonValueSource::new(self.source))
         }
     }
 
-    impl<'a, 'de: 'a, R: Read> SeqAccess<'de> for JsonValueSource<'a, R> {
+    impl<'a, 'de: 'a, S: JsonEventSource> SeqAccess<'de> for JsonValueSource<'a, S> {
         type Error = SerDeIoError;
 
         fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
@@ -891,7 +913,7 @@ mod de {
             match self.next_event_static()? {
                 JsonEvent::EndArray => Ok(None),
                 event => seed
-                    .deserialize(JsonValueSource::new(self.reader).with_peek(event))
+                    .deserialize(JsonValueSource::new(self.source).with_peek(event))
                     .map(Some),
             }
         }
@@ -941,20 +963,6 @@ mod de {
                 JsonNumber::U64(v) => visitor.visit_u64(v),
                 JsonNumber::F64(v) => visitor.visit_f64(v),
             }
-        }
-    }
-
-    fn event_to_static<'a, V: Borrow<JsonEvent<'a>>>(event: V) -> JsonEvent<'static> {
-        match event.borrow() {
-            JsonEvent::String(v) => JsonEvent::String(Cow::Owned(v.to_string())),
-            JsonEvent::Number(v) => JsonEvent::Number(Cow::Owned(v.to_string())),
-            JsonEvent::Boolean(v) => JsonEvent::Boolean(*v),
-            JsonEvent::Null => JsonEvent::Null,
-            JsonEvent::StartArray => JsonEvent::StartArray,
-            JsonEvent::EndArray => JsonEvent::EndArray,
-            JsonEvent::StartObject => JsonEvent::StartObject,
-            JsonEvent::EndObject => JsonEvent::EndObject,
-            JsonEvent::ObjectKey(k) => JsonEvent::ObjectKey(Cow::Owned(k.to_string())),
         }
     }
 

--- a/src/skipper.rs
+++ b/src/skipper.rs
@@ -1,0 +1,177 @@
+use crate::JsonEvent;
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter};
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum SkipError {
+    SkipAlreadyDone,
+    StackEmpty,
+}
+
+impl Display for SkipError {
+    #[inline]
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SkipError::SkipAlreadyDone => write!(f, "Skip already done"),
+            SkipError::StackEmpty => write!(f, "Stack is empty (trying to skip after done?)"),
+        }
+    }
+}
+
+impl Error for SkipError {}
+
+#[derive(Copy, Clone)]
+pub struct Skipper {
+    has_skipped_value: bool,
+    depth: usize,
+}
+
+impl Default for Skipper {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Skipper {
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            has_skipped_value: false,
+            depth: 0,
+        }
+    }
+
+    #[inline]
+    pub fn skipping(&self) -> bool {
+        !self.has_skipped_value || self.depth > 0
+    }
+
+    pub fn reset(&mut self) {
+        self.has_skipped_value = false;
+        self.depth = 0;
+    }
+
+    pub fn on_event(&mut self, event: &JsonEvent<'_>) -> Result<bool, SkipError> {
+        if !self.skipping() {
+            return Err(SkipError::SkipAlreadyDone);
+        }
+
+        match event {
+            JsonEvent::String(_)
+            | JsonEvent::Number(_)
+            | JsonEvent::Boolean(_)
+            | JsonEvent::Null => {
+                self.has_skipped_value = true;
+            }
+            JsonEvent::StartArray | JsonEvent::StartObject => {
+                self.has_skipped_value = true;
+                self.depth += 1;
+            }
+            JsonEvent::EndArray | JsonEvent::EndObject => {
+                if self.depth == 0 {
+                    return Err(SkipError::StackEmpty);
+                }
+                self.depth = self.depth - 1;
+            }
+            JsonEvent::ObjectKey(_) => {
+                // value key, do nothing
+            }
+        }
+
+        Ok(self.skipping())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{JsonEvent, ReaderJsonParser, Skipper};
+
+    fn skip_test(json: &str, check_y: &str) {
+        #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+        enum State {
+            WaitScope,
+            InScopeWaitX,
+            InScopeSkippingWaitY,
+            InScopeWaitYValue,
+            WaitEndScope,
+            Done,
+        }
+
+        let mut reader = ReaderJsonParser::new(json.as_bytes());
+        let mut skipper = Skipper::new();
+        let mut state = State::WaitScope;
+        let mut y: Option<String> = None;
+
+        while let Some(event) = reader.parse_next() {
+            let event = event.unwrap();
+            match event {
+                JsonEvent::StartObject if state == State::WaitScope => {
+                    state = State::InScopeWaitX;
+                }
+                JsonEvent::EndObject if state == State::WaitEndScope => {
+                    state = State::Done;
+                }
+                JsonEvent::ObjectKey(k) if state == State::InScopeWaitX && k == "x" => {
+                    state = State::InScopeSkippingWaitY;
+                }
+                event if state == State::InScopeSkippingWaitY && skipper.skipping() => {
+                    skipper.on_event(&event).unwrap();
+                }
+                JsonEvent::ObjectKey(k) if state == State::InScopeSkippingWaitY && k == "y" => {
+                    state = State::InScopeWaitYValue;
+                }
+                JsonEvent::Number(v) if state == State::InScopeWaitYValue => {
+                    state = State::WaitEndScope;
+                    y = Some(v.to_string());
+                }
+                event => {
+                    panic!("unexpected event {:?} of state {:?}", event, state);
+                }
+            }
+        }
+
+        assert!(!skipper.skipping());
+        assert_eq!(state, State::Done);
+        assert_eq!(y.as_deref(), Some(check_y));
+    }
+
+    #[test]
+    fn skip_single_value() {
+        skip_test(
+            r#"
+                {
+                    "x": 1,
+                    "y": 2
+                }
+            "#,
+            "2",
+        );
+    }
+
+    #[test]
+    fn skip_object() {
+        skip_test(
+            r#"
+                {
+                    "x": {"sub_a": true, "sub_b": "text", "sub_c": []},
+                    "y": 2
+                }
+            "#,
+            "2",
+        );
+    }
+
+    #[test]
+    fn skip_array() {
+        skip_test(
+            r#"
+                {
+                    "x": [1, true, "text", {}],
+                    "y": 2
+                }
+            "#,
+            "2",
+        );
+    }
+}

--- a/src/skipper.rs
+++ b/src/skipper.rs
@@ -24,16 +24,16 @@ impl Display for SkipError {
 impl Error for SkipError {}
 
 pub trait SkipRecorder {
-    fn on_event(&mut self, event: JsonEvent<'static>);
+    fn on_event(&mut self, event: &JsonEvent<'_>);
 }
 
 impl SkipRecorder for () {
-    fn on_event(&mut self, _event: JsonEvent<'static>) {}
+    fn on_event(&mut self, _event: &JsonEvent<'_>) {}
 }
 
 impl SkipRecorder for &mut Vec<JsonEvent<'static>> {
-    fn on_event(&mut self, event: JsonEvent<'static>) {
-        self.push(event);
+    fn on_event(&mut self, event: &JsonEvent<'_>) {
+        self.push(owned_event(event.clone()));
     }
 }
 
@@ -108,7 +108,7 @@ where
             }
         }
 
-        self.recorder.on_event(owned_event(event.clone()));
+        self.recorder.on_event(event);
 
         Ok(self.skipping())
     }

--- a/src/skipper.rs
+++ b/src/skipper.rs
@@ -1,11 +1,13 @@
 use crate::JsonEvent;
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
+use crate::read::owned_event;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum SkipError {
     SkipAlreadyDone,
     StackEmpty,
+    NestedObjectKey,
 }
 
 impl Display for SkipError {
@@ -14,31 +16,56 @@ impl Display for SkipError {
         match self {
             SkipError::SkipAlreadyDone => write!(f, "Skip already done"),
             SkipError::StackEmpty => write!(f, "Stack is empty (trying to skip after done?)"),
+            SkipError::NestedObjectKey => write!(f, "Nested object key"),
         }
     }
 }
 
 impl Error for SkipError {}
 
-#[derive(Copy, Clone)]
-pub struct Skipper {
-    has_skipped_value: bool,
-    depth: usize,
+pub trait SkipRecorder {
+    fn on_event(&mut self, event: JsonEvent<'static>);
 }
 
-impl Default for Skipper {
-    #[inline]
-    fn default() -> Self {
-        Self::new()
+impl SkipRecorder for () {
+    fn on_event(&mut self, _event: JsonEvent<'static>) {}
+}
+
+impl SkipRecorder for &mut Vec<JsonEvent<'static>> {
+    fn on_event(&mut self, event: JsonEvent<'static>) {
+        self.push(event);
     }
 }
 
-impl Skipper {
+pub struct Skipper<R = ()>
+where
+    R: SkipRecorder,
+{
+    has_skipped_value: bool,
+    depth: usize,
+    recorder: R,
+}
+
+impl<R> Default for Skipper<R>
+where
+    R: Default + SkipRecorder,
+{
     #[inline]
-    pub const fn new() -> Self {
+    fn default() -> Self {
+        Skipper::new(R::default())
+    }
+}
+
+impl<R> Skipper<R>
+where
+    R: SkipRecorder,
+{
+    #[inline]
+    pub const fn new(recorder: R) -> Self {
         Self {
             has_skipped_value: false,
             depth: 0,
+            recorder,
         }
     }
 
@@ -72,12 +99,16 @@ impl Skipper {
                 if self.depth == 0 {
                     return Err(SkipError::StackEmpty);
                 }
-                self.depth = self.depth - 1;
+                self.depth -= 1;
             }
             JsonEvent::ObjectKey(_) => {
-                // value key, do nothing
+                if self.depth == 0 {
+                    return Err(SkipError::NestedObjectKey);
+                }
             }
         }
+
+        self.recorder.on_event(owned_event(event.clone()));
 
         Ok(self.skipping())
     }
@@ -99,7 +130,7 @@ mod test {
         }
 
         let mut reader = ReaderJsonParser::new(json.as_bytes());
-        let mut skipper = Skipper::new();
+        let mut skipper = Skipper::<()>::default();
         let mut state = State::WaitScope;
         let mut y: Option<String> = None;
 

--- a/src/skipper.rs
+++ b/src/skipper.rs
@@ -1,7 +1,6 @@
 use crate::JsonEvent;
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
-use crate::read::owned_event;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum SkipError {
@@ -23,49 +22,25 @@ impl Display for SkipError {
 
 impl Error for SkipError {}
 
-pub trait SkipRecorder {
-    fn on_event(&mut self, event: &JsonEvent<'_>);
-}
-
-impl SkipRecorder for () {
-    fn on_event(&mut self, _event: &JsonEvent<'_>) {}
-}
-
-impl SkipRecorder for &mut Vec<JsonEvent<'static>> {
-    fn on_event(&mut self, event: &JsonEvent<'_>) {
-        self.push(owned_event(event.clone()));
-    }
-}
-
-pub struct Skipper<R = ()>
-where
-    R: SkipRecorder,
-{
+#[derive(Copy, Clone)]
+pub struct Skipper {
     has_skipped_value: bool,
     depth: usize,
-    recorder: R,
 }
 
-impl<R> Default for Skipper<R>
-where
-    R: Default + SkipRecorder,
-{
+impl Default for Skipper {
     #[inline]
     fn default() -> Self {
-        Skipper::new(R::default())
+        Skipper::new()
     }
 }
 
-impl<R> Skipper<R>
-where
-    R: SkipRecorder,
-{
+impl Skipper {
     #[inline]
-    pub const fn new(recorder: R) -> Self {
+    pub const fn new() -> Self {
         Self {
             has_skipped_value: false,
             depth: 0,
-            recorder,
         }
     }
 
@@ -108,8 +83,6 @@ where
             }
         }
 
-        self.recorder.on_event(event);
-
         Ok(self.skipping())
     }
 }
@@ -130,7 +103,7 @@ mod test {
         }
 
         let mut reader = ReaderJsonParser::new(json.as_bytes());
-        let mut skipper = Skipper::<()>::default();
+        let mut skipper = Skipper::new();
         let mut state = State::WaitScope;
         let mut y: Option<String> = None;
 

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "serde")]
 
 use std::borrow::Cow;
-use json_event_parser::{JsonEvent, JsonValueSink, JsonValueSource, ReaderJsonParser, WriterJsonSerializer};
+use json_event_parser::{JsonEvent, JsonValueSink, JsonValueSource, ReaderJsonParser, Skipper, WriterJsonSerializer};
 use serde::{Deserialize, Serialize};
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
@@ -82,6 +82,33 @@ fn part_source_object() {
     assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::Number(Cow::Borrowed("1")));
     assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::ObjectKey(Cow::Borrowed("y")));
     let demo_decoded = DemoStruct::deserialize(JsonValueSource::new(&mut json_reader)).unwrap();
+    assert_eq!(demo_input, demo_decoded);
+    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::ObjectKey(Cow::Borrowed("z")));
+    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::Number(Cow::Borrowed("2")));
+    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::EndObject);
+    assert!(json_reader.parse_next().is_none());
+}
+
+#[test]
+fn skip_and_consume() {
+    let demo_input = DemoStruct::demo();
+    let demo_json = serde_json::to_string(&demo_input).unwrap();
+    let composed_demo_json = format!("{{\"x\": 1, \"y\": {}, \"z\": 2}}", demo_json);
+
+    let mut json_reader = ReaderJsonParser::new(composed_demo_json.as_bytes());
+    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::StartObject);
+    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::ObjectKey(Cow::Borrowed("x")));
+    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::Number(Cow::Borrowed("1")));
+    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::ObjectKey(Cow::Borrowed("y")));
+    
+    let mut events = Vec::<JsonEvent<'static>>::new();
+    let mut skipper = Skipper::new(&mut events);
+    while skipper.skipping() {
+        skipper.on_event(&json_reader.parse_next().unwrap().unwrap()).unwrap();
+    }
+    
+    let demo_decoded = DemoStruct::deserialize(JsonValueSource::new(&mut events)).unwrap();
+    
     assert_eq!(demo_input, demo_decoded);
     assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::ObjectKey(Cow::Borrowed("z")));
     assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::Number(Cow::Borrowed("2")));

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::blocks_in_conditions, clippy::redundant_static_lifetimes)]
 #![cfg(feature = "serde")]
 
-use json_event_parser::{JsonValueSink, JsonValueSource, ReaderJsonParser, WriterJsonSerializer};
+use std::borrow::Cow;
+use json_event_parser::{JsonEvent, JsonValueSink, JsonValueSource, ReaderJsonParser, WriterJsonSerializer};
 use serde::{Deserialize, Serialize};
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
@@ -67,6 +68,25 @@ fn source_object() {
     let mut json_reader = ReaderJsonParser::new(demo_json.as_bytes());
     let demo_decoded = DemoStruct::deserialize(JsonValueSource::new(&mut json_reader)).unwrap();
     assert_eq!(demo_input, demo_decoded);
+}
+
+#[test]
+fn part_source_object() {
+    let demo_input = DemoStruct::demo();
+    let demo_json = serde_json::to_string(&demo_input).unwrap();
+    let composed_demo_json = format!("{{\"x\": 1, \"y\": {}, \"z\": 2}}", demo_json);
+
+    let mut json_reader = ReaderJsonParser::new(composed_demo_json.as_bytes());
+    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::StartObject);
+    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::ObjectKey(Cow::Borrowed("x")));
+    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::Number(Cow::Borrowed("1")));
+    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::ObjectKey(Cow::Borrowed("y")));
+    let demo_decoded = DemoStruct::deserialize(JsonValueSource::new(&mut json_reader)).unwrap();
+    assert_eq!(demo_input, demo_decoded);
+    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::ObjectKey(Cow::Borrowed("z")));
+    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::Number(Cow::Borrowed("2")));
+    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::EndObject);
+    assert!(json_reader.parse_next().is_none());
 }
 
 // serde derive expansion code below, for debugging purpose only, do **NOT** edit

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,9 +1,12 @@
 #![allow(clippy::blocks_in_conditions, clippy::redundant_static_lifetimes)]
 #![cfg(feature = "serde")]
 
-use std::borrow::Cow;
-use json_event_parser::{JsonEvent, JsonValueSink, JsonValueSource, ReaderJsonParser, Skipper, WriterJsonSerializer};
+use json_event_parser::{
+    owned_event, JsonEvent, JsonValueSink, JsonValueSource, ReaderJsonParser, Skipper,
+    WriterJsonSerializer,
+};
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 enum DemoEnum {
@@ -77,15 +80,36 @@ fn part_source_object() {
     let composed_demo_json = format!("{{\"x\": 1, \"y\": {}, \"z\": 2}}", demo_json);
 
     let mut json_reader = ReaderJsonParser::new(composed_demo_json.as_bytes());
-    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::StartObject);
-    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::ObjectKey(Cow::Borrowed("x")));
-    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::Number(Cow::Borrowed("1")));
-    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::ObjectKey(Cow::Borrowed("y")));
+    assert_eq!(
+        json_reader.parse_next().unwrap().unwrap(),
+        JsonEvent::StartObject
+    );
+    assert_eq!(
+        json_reader.parse_next().unwrap().unwrap(),
+        JsonEvent::ObjectKey(Cow::Borrowed("x"))
+    );
+    assert_eq!(
+        json_reader.parse_next().unwrap().unwrap(),
+        JsonEvent::Number(Cow::Borrowed("1"))
+    );
+    assert_eq!(
+        json_reader.parse_next().unwrap().unwrap(),
+        JsonEvent::ObjectKey(Cow::Borrowed("y"))
+    );
     let demo_decoded = DemoStruct::deserialize(JsonValueSource::new(&mut json_reader)).unwrap();
     assert_eq!(demo_input, demo_decoded);
-    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::ObjectKey(Cow::Borrowed("z")));
-    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::Number(Cow::Borrowed("2")));
-    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::EndObject);
+    assert_eq!(
+        json_reader.parse_next().unwrap().unwrap(),
+        JsonEvent::ObjectKey(Cow::Borrowed("z"))
+    );
+    assert_eq!(
+        json_reader.parse_next().unwrap().unwrap(),
+        JsonEvent::Number(Cow::Borrowed("2"))
+    );
+    assert_eq!(
+        json_reader.parse_next().unwrap().unwrap(),
+        JsonEvent::EndObject
+    );
     assert!(json_reader.parse_next().is_none());
 }
 
@@ -96,23 +120,46 @@ fn skip_and_consume() {
     let composed_demo_json = format!("{{\"x\": 1, \"y\": {}, \"z\": 2}}", demo_json);
 
     let mut json_reader = ReaderJsonParser::new(composed_demo_json.as_bytes());
-    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::StartObject);
-    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::ObjectKey(Cow::Borrowed("x")));
-    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::Number(Cow::Borrowed("1")));
-    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::ObjectKey(Cow::Borrowed("y")));
-    
+    assert_eq!(
+        json_reader.parse_next().unwrap().unwrap(),
+        JsonEvent::StartObject
+    );
+    assert_eq!(
+        json_reader.parse_next().unwrap().unwrap(),
+        JsonEvent::ObjectKey(Cow::Borrowed("x"))
+    );
+    assert_eq!(
+        json_reader.parse_next().unwrap().unwrap(),
+        JsonEvent::Number(Cow::Borrowed("1"))
+    );
+    assert_eq!(
+        json_reader.parse_next().unwrap().unwrap(),
+        JsonEvent::ObjectKey(Cow::Borrowed("y"))
+    );
+
     let mut events = Vec::<JsonEvent<'static>>::new();
-    let mut skipper = Skipper::new(&mut events);
+    let mut skipper = Skipper::new();
     while skipper.skipping() {
-        skipper.on_event(&json_reader.parse_next().unwrap().unwrap()).unwrap();
+        let event = json_reader.parse_next().unwrap().unwrap();
+        skipper.on_event(&event).unwrap();
+        events.push(owned_event(event.clone()));
     }
-    
+
     let demo_decoded = DemoStruct::deserialize(JsonValueSource::new(&mut events)).unwrap();
-    
+
     assert_eq!(demo_input, demo_decoded);
-    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::ObjectKey(Cow::Borrowed("z")));
-    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::Number(Cow::Borrowed("2")));
-    assert_eq!(json_reader.parse_next().unwrap().unwrap(), JsonEvent::EndObject);
+    assert_eq!(
+        json_reader.parse_next().unwrap().unwrap(),
+        JsonEvent::ObjectKey(Cow::Borrowed("z"))
+    );
+    assert_eq!(
+        json_reader.parse_next().unwrap().unwrap(),
+        JsonEvent::Number(Cow::Borrowed("2"))
+    );
+    assert_eq!(
+        json_reader.parse_next().unwrap().unwrap(),
+        JsonEvent::EndObject
+    );
     assert!(json_reader.parse_next().is_none());
 }
 

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,1387 @@
+#![allow(clippy::blocks_in_conditions, clippy::redundant_static_lifetimes)]
+#![cfg(feature = "serde")]
+
+use json_event_parser::{JsonValueSink, JsonValueSource, ReaderJsonParser, WriterJsonSerializer};
+use serde::{Deserialize, Serialize};
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum DemoEnum {
+    A,
+    Ary2,
+    Ary1,
+    Ary3,
+    Inner,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum DemoValueEnum {
+    U8(u8),
+    None,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+struct DemoInnerStruct {
+    enum_k: DemoEnum,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+struct DemoStruct {
+    enum_k: DemoEnum,
+    inner_struct: DemoInnerStruct,
+    array: Vec<DemoEnum>,
+    enum_with_value: Vec<DemoValueEnum>,
+}
+
+impl DemoStruct {
+    fn demo() -> Self {
+        Self {
+            enum_k: DemoEnum::A,
+            inner_struct: DemoInnerStruct {
+                enum_k: DemoEnum::Inner,
+            },
+            array: vec![DemoEnum::Ary1, DemoEnum::Ary2, DemoEnum::Ary3],
+            enum_with_value: vec![DemoValueEnum::U8(42), DemoValueEnum::None],
+        }
+    }
+}
+
+#[test]
+fn sink_object() {
+    let demo_input = DemoStruct::demo();
+
+    let mut write = Vec::<u8>::new();
+    let mut json_writer = WriterJsonSerializer::new(&mut write);
+    demo_input
+        .serialize(JsonValueSink::new(&mut json_writer))
+        .unwrap();
+
+    let demo_decode = serde_json::from_slice::<DemoStruct>(&write).unwrap();
+    assert_eq!(demo_input, demo_decode);
+}
+
+#[test]
+fn source_object() {
+    let demo_input = DemoStruct::demo();
+    let demo_json = serde_json::to_string(&demo_input).unwrap();
+
+    let mut json_reader = ReaderJsonParser::new(demo_json.as_bytes());
+    let demo_decoded = DemoStruct::deserialize(JsonValueSource::new(&mut json_reader)).unwrap();
+    assert_eq!(demo_input, demo_decoded);
+}
+
+// serde derive expansion code below, for debugging purpose only, do **NOT** edit
+// if you want update these code, use IDE or something support macro expansion for generated code from serde `derive(Serialize, Deserialize)`
+
+#[doc(hidden)]
+#[allow(
+    non_upper_case_globals,
+    unused_attributes,
+    unused_qualifications,
+    clippy::absolute_paths
+)]
+const _: () = {
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
+    extern crate serde as _serde;
+    _serde::__require_serde_not_serde_core!();
+    #[automatically_derived]
+    impl _serde::Serialize for DemoEnum {
+        fn serialize<__S>(
+            &self,
+            __serializer: __S,
+        ) -> _serde::__private229::Result<__S::Ok, __S::Error>
+        where
+            __S: _serde::Serializer,
+        {
+            match *self {
+                DemoEnum::A => {
+                    _serde::Serializer::serialize_unit_variant(__serializer, "DemoEnum", 0u32, "a")
+                }
+                DemoEnum::Ary2 => _serde::Serializer::serialize_unit_variant(
+                    __serializer,
+                    "DemoEnum",
+                    1u32,
+                    "ary2",
+                ),
+                DemoEnum::Ary1 => _serde::Serializer::serialize_unit_variant(
+                    __serializer,
+                    "DemoEnum",
+                    2u32,
+                    "ary1",
+                ),
+                DemoEnum::Ary3 => _serde::Serializer::serialize_unit_variant(
+                    __serializer,
+                    "DemoEnum",
+                    3u32,
+                    "ary3",
+                ),
+                DemoEnum::Inner => _serde::Serializer::serialize_unit_variant(
+                    __serializer,
+                    "DemoEnum",
+                    4u32,
+                    "inner",
+                ),
+            }
+        }
+    }
+};
+
+#[doc(hidden)]
+#[allow(
+    non_upper_case_globals,
+    unused_attributes,
+    unused_qualifications,
+    clippy::absolute_paths
+)]
+const _: () = {
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
+    extern crate serde as _serde;
+    _serde::__require_serde_not_serde_core!();
+    #[automatically_derived]
+    impl<'de> _serde::Deserialize<'de> for DemoEnum {
+        fn deserialize<__D>(__deserializer: __D) -> _serde::__private229::Result<Self, __D::Error>
+        where
+            __D: _serde::Deserializer<'de>,
+        {
+            #[allow(non_camel_case_types)]
+            #[doc(hidden)]
+            enum __Field {
+                __field0,
+                __field1,
+                __field2,
+                __field3,
+                __field4,
+            }
+            #[doc(hidden)]
+            struct __FieldVisitor;
+            #[automatically_derived]
+            impl<'de> _serde::de::Visitor<'de> for __FieldVisitor {
+                type Value = __Field;
+                fn expecting(
+                    &self,
+                    __formatter: &mut _serde::__private229::Formatter<'_>,
+                ) -> _serde::__private229::fmt::Result {
+                    _serde::__private229::Formatter::write_str(__formatter, "variant identifier")
+                }
+                fn visit_u64<__E>(
+                    self,
+                    __value: u64,
+                ) -> _serde::__private229::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        0u64 => _serde::__private229::Ok(__Field::__field0),
+                        1u64 => _serde::__private229::Ok(__Field::__field1),
+                        2u64 => _serde::__private229::Ok(__Field::__field2),
+                        3u64 => _serde::__private229::Ok(__Field::__field3),
+                        4u64 => _serde::__private229::Ok(__Field::__field4),
+                        _ => _serde::__private229::Err(_serde::de::Error::invalid_value(
+                            _serde::de::Unexpected::Unsigned(__value),
+                            &"variant index 0 <= i < 5",
+                        )),
+                    }
+                }
+                fn visit_str<__E>(
+                    self,
+                    __value: &str,
+                ) -> _serde::__private229::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        "a" => _serde::__private229::Ok(__Field::__field0),
+                        "ary2" => _serde::__private229::Ok(__Field::__field1),
+                        "ary1" => _serde::__private229::Ok(__Field::__field2),
+                        "ary3" => _serde::__private229::Ok(__Field::__field3),
+                        "inner" => _serde::__private229::Ok(__Field::__field4),
+                        _ => _serde::__private229::Err(_serde::de::Error::unknown_variant(
+                            __value, VARIANTS,
+                        )),
+                    }
+                }
+                fn visit_bytes<__E>(
+                    self,
+                    __value: &[u8],
+                ) -> _serde::__private229::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        b"a" => _serde::__private229::Ok(__Field::__field0),
+                        b"ary2" => _serde::__private229::Ok(__Field::__field1),
+                        b"ary1" => _serde::__private229::Ok(__Field::__field2),
+                        b"ary3" => _serde::__private229::Ok(__Field::__field3),
+                        b"inner" => _serde::__private229::Ok(__Field::__field4),
+                        _ => {
+                            let __value = &_serde::__private229::from_utf8_lossy(__value);
+                            _serde::__private229::Err(_serde::de::Error::unknown_variant(
+                                __value, VARIANTS,
+                            ))
+                        }
+                    }
+                }
+            }
+            #[automatically_derived]
+            impl<'de> _serde::Deserialize<'de> for __Field {
+                #[inline]
+                fn deserialize<__D>(
+                    __deserializer: __D,
+                ) -> _serde::__private229::Result<Self, __D::Error>
+                where
+                    __D: _serde::Deserializer<'de>,
+                {
+                    _serde::Deserializer::deserialize_identifier(__deserializer, __FieldVisitor)
+                }
+            }
+            #[doc(hidden)]
+            struct __Visitor<'de> {
+                marker: _serde::__private229::PhantomData<DemoEnum>,
+                lifetime: _serde::__private229::PhantomData<&'de ()>,
+            }
+            #[automatically_derived]
+            impl<'de> _serde::de::Visitor<'de> for __Visitor<'de> {
+                type Value = DemoEnum;
+                fn expecting(
+                    &self,
+                    __formatter: &mut _serde::__private229::Formatter<'_>,
+                ) -> _serde::__private229::fmt::Result {
+                    _serde::__private229::Formatter::write_str(__formatter, "enum DemoEnum")
+                }
+                fn visit_enum<__A>(
+                    self,
+                    __data: __A,
+                ) -> _serde::__private229::Result<Self::Value, __A::Error>
+                where
+                    __A: _serde::de::EnumAccess<'de>,
+                {
+                    match _serde::de::EnumAccess::variant(__data) {
+                        _serde::__private229::Ok((__Field::__field0, __variant)) => {
+                            _serde::de::VariantAccess::unit_variant(__variant)?;
+                            _serde::__private229::Ok(DemoEnum::A)
+                        }
+                        _serde::__private229::Ok((__Field::__field1, __variant)) => {
+                            _serde::de::VariantAccess::unit_variant(__variant)?;
+                            _serde::__private229::Ok(DemoEnum::Ary2)
+                        }
+                        _serde::__private229::Ok((__Field::__field2, __variant)) => {
+                            _serde::de::VariantAccess::unit_variant(__variant)?;
+                            _serde::__private229::Ok(DemoEnum::Ary1)
+                        }
+                        _serde::__private229::Ok((__Field::__field3, __variant)) => {
+                            _serde::de::VariantAccess::unit_variant(__variant)?;
+                            _serde::__private229::Ok(DemoEnum::Ary3)
+                        }
+                        _serde::__private229::Ok((__Field::__field4, __variant)) => {
+                            _serde::de::VariantAccess::unit_variant(__variant)?;
+                            _serde::__private229::Ok(DemoEnum::Inner)
+                        }
+                        _serde::__private229::Err(__err) => _serde::__private229::Err(__err),
+                    }
+                }
+            }
+            #[doc(hidden)]
+            const VARIANTS: &'static [&'static str] = &["a", "ary2", "ary1", "ary3", "inner"];
+            _serde::Deserializer::deserialize_enum(
+                __deserializer,
+                "DemoEnum",
+                VARIANTS,
+                __Visitor {
+                    marker: _serde::__private229::PhantomData::<DemoEnum>,
+                    lifetime: _serde::__private229::PhantomData,
+                },
+            )
+        }
+    }
+};
+
+#[doc(hidden)]
+#[allow(
+    non_upper_case_globals,
+    unused_attributes,
+    unused_qualifications,
+    clippy::absolute_paths
+)]
+const _: () = {
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
+    extern crate serde as _serde;
+    _serde::__require_serde_not_serde_core!();
+    #[automatically_derived]
+    impl _serde::Serialize for DemoValueEnum {
+        fn serialize<__S>(
+            &self,
+            __serializer: __S,
+        ) -> _serde::__private229::Result<__S::Ok, __S::Error>
+        where
+            __S: _serde::Serializer,
+        {
+            match *self {
+                DemoValueEnum::U8(ref __field0) => {
+                    let mut __struct =
+                        _serde::Serializer::serialize_struct(__serializer, "DemoValueEnum", 2)?;
+                    _serde::ser::SerializeStruct::serialize_field(
+                        &mut __struct,
+                        "type",
+                        &_serde::__private229::ser::AdjacentlyTaggedEnumVariant {
+                            enum_name: "DemoValueEnum",
+                            variant_index: 0u32,
+                            variant_name: "u8",
+                        },
+                    )?;
+                    _serde::ser::SerializeStruct::serialize_field(&mut __struct, "data", __field0)?;
+                    _serde::ser::SerializeStruct::end(__struct)
+                }
+                DemoValueEnum::None => {
+                    let mut __struct =
+                        _serde::Serializer::serialize_struct(__serializer, "DemoValueEnum", 1)?;
+                    _serde::ser::SerializeStruct::serialize_field(
+                        &mut __struct,
+                        "type",
+                        &_serde::__private229::ser::AdjacentlyTaggedEnumVariant {
+                            enum_name: "DemoValueEnum",
+                            variant_index: 1u32,
+                            variant_name: "none",
+                        },
+                    )?;
+                    _serde::ser::SerializeStruct::end(__struct)
+                }
+            }
+        }
+    }
+};
+
+#[doc(hidden)]
+#[allow(
+    non_upper_case_globals,
+    unused_attributes,
+    unused_qualifications,
+    clippy::absolute_paths
+)]
+const _: () = {
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
+    extern crate serde as _serde;
+    _serde::__require_serde_not_serde_core!();
+    #[automatically_derived]
+    impl<'de> _serde::Deserialize<'de> for DemoValueEnum {
+        fn deserialize<__D>(__deserializer: __D) -> _serde::__private229::Result<Self, __D::Error>
+        where
+            __D: _serde::Deserializer<'de>,
+        {
+            #[allow(non_camel_case_types)]
+            #[doc(hidden)]
+            enum __Field {
+                __field0,
+                __field1,
+            }
+            #[doc(hidden)]
+            struct __FieldVisitor;
+            #[automatically_derived]
+            impl<'de> _serde::de::Visitor<'de> for __FieldVisitor {
+                type Value = __Field;
+                fn expecting(
+                    &self,
+                    __formatter: &mut _serde::__private229::Formatter<'_>,
+                ) -> _serde::__private229::fmt::Result {
+                    _serde::__private229::Formatter::write_str(__formatter, "variant identifier")
+                }
+                fn visit_u64<__E>(
+                    self,
+                    __value: u64,
+                ) -> _serde::__private229::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        0u64 => _serde::__private229::Ok(__Field::__field0),
+                        1u64 => _serde::__private229::Ok(__Field::__field1),
+                        _ => _serde::__private229::Err(_serde::de::Error::invalid_value(
+                            _serde::de::Unexpected::Unsigned(__value),
+                            &"variant index 0 <= i < 2",
+                        )),
+                    }
+                }
+                fn visit_str<__E>(
+                    self,
+                    __value: &str,
+                ) -> _serde::__private229::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        "u8" => _serde::__private229::Ok(__Field::__field0),
+                        "none" => _serde::__private229::Ok(__Field::__field1),
+                        _ => _serde::__private229::Err(_serde::de::Error::unknown_variant(
+                            __value, VARIANTS,
+                        )),
+                    }
+                }
+                fn visit_bytes<__E>(
+                    self,
+                    __value: &[u8],
+                ) -> _serde::__private229::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        b"u8" => _serde::__private229::Ok(__Field::__field0),
+                        b"none" => _serde::__private229::Ok(__Field::__field1),
+                        _ => {
+                            let __value = &_serde::__private229::from_utf8_lossy(__value);
+                            _serde::__private229::Err(_serde::de::Error::unknown_variant(
+                                __value, VARIANTS,
+                            ))
+                        }
+                    }
+                }
+            }
+            #[automatically_derived]
+            impl<'de> _serde::Deserialize<'de> for __Field {
+                #[inline]
+                fn deserialize<__D>(
+                    __deserializer: __D,
+                ) -> _serde::__private229::Result<Self, __D::Error>
+                where
+                    __D: _serde::Deserializer<'de>,
+                {
+                    _serde::Deserializer::deserialize_identifier(__deserializer, __FieldVisitor)
+                }
+            }
+            #[doc(hidden)]
+            const VARIANTS: &'static [&'static str] = &["u8", "none"];
+            #[doc(hidden)]
+            struct __Seed<'de> {
+                variant: __Field,
+                marker: _serde::__private229::PhantomData<DemoValueEnum>,
+                lifetime: _serde::__private229::PhantomData<&'de ()>,
+            }
+            #[automatically_derived]
+            impl<'de> _serde::de::DeserializeSeed<'de> for __Seed<'de> {
+                type Value = DemoValueEnum;
+                fn deserialize<__D>(
+                    self,
+                    __deserializer: __D,
+                ) -> _serde::__private229::Result<Self::Value, __D::Error>
+                where
+                    __D: _serde::Deserializer<'de>,
+                {
+                    match self.variant {
+                        __Field::__field0 => _serde::__private229::Result::map(
+                            <u8 as _serde::Deserialize>::deserialize(__deserializer),
+                            DemoValueEnum::U8,
+                        ),
+                        __Field::__field1 => match _serde::Deserializer::deserialize_any(
+                            __deserializer,
+                            _serde::__private229::de::UntaggedUnitVisitor::new(
+                                "DemoValueEnum",
+                                "None",
+                            ),
+                        ) {
+                            _serde::__private229::Ok(()) => {
+                                _serde::__private229::Ok(DemoValueEnum::None)
+                            }
+                            _serde::__private229::Err(__err) => _serde::__private229::Err(__err),
+                        },
+                    }
+                }
+            }
+            #[doc(hidden)]
+            struct __Visitor<'de> {
+                marker: _serde::__private229::PhantomData<DemoValueEnum>,
+                lifetime: _serde::__private229::PhantomData<&'de ()>,
+            }
+            //noinspection RsSortImplTraitMembers
+            #[automatically_derived]
+            impl<'de> _serde::de::Visitor<'de> for __Visitor<'de> {
+                type Value = DemoValueEnum;
+                fn expecting(
+                    &self,
+                    __formatter: &mut _serde::__private229::Formatter<'_>,
+                ) -> _serde::__private229::fmt::Result {
+                    _serde::__private229::Formatter::write_str(
+                        __formatter,
+                        "adjacently tagged enum DemoValueEnum",
+                    )
+                }
+                fn visit_map<__A>(
+                    self,
+                    mut __map: __A,
+                ) -> _serde::__private229::Result<Self::Value, __A::Error>
+                where
+                    __A: _serde::de::MapAccess<'de>,
+                {
+                    match {
+                        let mut __rk: _serde::__private229::Option<
+                            _serde::__private229::de::TagOrContentField,
+                        > = _serde::__private229::None;
+                        while let _serde::__private229::Some(__k) =
+                            _serde::de::MapAccess::next_key_seed(
+                                &mut __map,
+                                _serde::__private229::de::TagContentOtherFieldVisitor {
+                                    tag: "type",
+                                    content: "data",
+                                },
+                            )?
+                        {
+                            match __k {
+                                _serde::__private229::de::TagContentOtherField::Other => {
+                                    let _ = _serde::de::MapAccess::next_value::<
+                                        _serde::de::IgnoredAny,
+                                    >(&mut __map)?;
+                                    continue;
+                                }
+                                _serde::__private229::de::TagContentOtherField::Tag => {
+                                    __rk = _serde::__private229::Some(
+                                        _serde::__private229::de::TagOrContentField::Tag,
+                                    );
+                                    break;
+                                }
+                                _serde::__private229::de::TagContentOtherField::Content => {
+                                    __rk = _serde::__private229::Some(
+                                        _serde::__private229::de::TagOrContentField::Content,
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                        __rk
+                    } {
+                        _serde::__private229::Some(
+                            _serde::__private229::de::TagOrContentField::Tag,
+                        ) => {
+                            let __field = _serde::de::MapAccess::next_value_seed(
+                                &mut __map,
+                                _serde::__private229::de::AdjacentlyTaggedEnumVariantSeed::<
+                                    __Field,
+                                > {
+                                    enum_name: "DemoValueEnum",
+                                    variants: VARIANTS,
+                                    fields_enum: _serde::__private229::PhantomData,
+                                },
+                            )?;
+                            match {
+                                let mut __rk: _serde::__private229::Option<
+                                    _serde::__private229::de::TagOrContentField,
+                                > = _serde::__private229::None;
+                                while let _serde::__private229::Some(__k) =
+                                    _serde::de::MapAccess::next_key_seed(
+                                        &mut __map,
+                                        _serde::__private229::de::TagContentOtherFieldVisitor {
+                                            tag: "type",
+                                            content: "data",
+                                        },
+                                    )?
+                                {
+                                    match __k {
+                                        _serde::__private229::de::TagContentOtherField::Other => {
+                                            let _ = _serde::de::MapAccess::next_value::<
+                                                _serde::de::IgnoredAny,
+                                            >(
+                                                &mut __map
+                                            )?;
+                                            continue;
+                                        }
+                                        _serde::__private229::de::TagContentOtherField::Tag => {
+                                            __rk = _serde::__private229::Some(
+                                                _serde::__private229::de::TagOrContentField::Tag,
+                                            );
+                                            break;
+                                        }
+                                        _serde::__private229::de::TagContentOtherField::Content => {
+                                            __rk = _serde::__private229::Some(_serde::__private229::de::TagOrContentField::Content);
+                                            break;
+                                        }
+                                    }
+                                }
+                                __rk
+                            } {
+                                _serde::__private229::Some(
+                                    _serde::__private229::de::TagOrContentField::Tag,
+                                ) => _serde::__private229::Err(
+                                    <__A::Error as _serde::de::Error>::duplicate_field("type"),
+                                ),
+                                _serde::__private229::Some(
+                                    _serde::__private229::de::TagOrContentField::Content,
+                                ) => {
+                                    let __ret = _serde::de::MapAccess::next_value_seed(
+                                        &mut __map,
+                                        __Seed {
+                                            variant: __field,
+                                            marker: _serde::__private229::PhantomData,
+                                            lifetime: _serde::__private229::PhantomData,
+                                        },
+                                    )?;
+                                    match {
+                                        let mut __rk: _serde::__private229::Option<
+                                            _serde::__private229::de::TagOrContentField,
+                                        > = _serde::__private229::None;
+                                        while let _serde::__private229::Some(__k) = _serde::de::MapAccess::next_key_seed(&mut __map, _serde::__private229::de::TagContentOtherFieldVisitor { tag: "type", content: "data" })? {
+                                                match __k {
+                                                    _serde::__private229::de::TagContentOtherField::Other => {
+                                                        let _ = _serde::de::MapAccess::next_value::<_serde::de::IgnoredAny>(&mut __map)?;
+                                                        continue;
+                                                    }
+                                                    _serde::__private229::de::TagContentOtherField::Tag => {
+                                                        __rk = _serde::__private229::Some(_serde::__private229::de::TagOrContentField::Tag);
+                                                        break;
+                                                    }
+                                                    _serde::__private229::de::TagContentOtherField::Content => {
+                                                        __rk = _serde::__private229::Some(_serde::__private229::de::TagOrContentField::Content);
+                                                        break;
+                                                    }
+                                                }
+                                            }
+                                        __rk
+                                    } {
+                                        _serde::__private229::Some(
+                                            _serde::__private229::de::TagOrContentField::Tag,
+                                        ) => _serde::__private229::Err(
+                                            <__A::Error as _serde::de::Error>::duplicate_field(
+                                                "type",
+                                            ),
+                                        ),
+                                        _serde::__private229::Some(
+                                            _serde::__private229::de::TagOrContentField::Content,
+                                        ) => _serde::__private229::Err(
+                                            <__A::Error as _serde::de::Error>::duplicate_field(
+                                                "data",
+                                            ),
+                                        ),
+                                        _serde::__private229::None => {
+                                            _serde::__private229::Ok(__ret)
+                                        }
+                                    }
+                                }
+                                _serde::__private229::None => match __field {
+                                    __Field::__field0 => {
+                                        _serde::__private229::de::missing_field("data")
+                                            .map(DemoValueEnum::U8)
+                                    }
+                                    __Field::__field1 => {
+                                        _serde::__private229::Ok(DemoValueEnum::None)
+                                    }
+                                },
+                            }
+                        }
+                        _serde::__private229::Some(
+                            _serde::__private229::de::TagOrContentField::Content,
+                        ) => {
+                            let __content = _serde::de::MapAccess::next_value_seed(
+                                &mut __map,
+                                _serde::__private229::de::ContentVisitor::new(),
+                            )?;
+                            match {
+                                let mut __rk: _serde::__private229::Option<
+                                    _serde::__private229::de::TagOrContentField,
+                                > = _serde::__private229::None;
+                                while let _serde::__private229::Some(__k) =
+                                    _serde::de::MapAccess::next_key_seed(
+                                        &mut __map,
+                                        _serde::__private229::de::TagContentOtherFieldVisitor {
+                                            tag: "type",
+                                            content: "data",
+                                        },
+                                    )?
+                                {
+                                    match __k {
+                                        _serde::__private229::de::TagContentOtherField::Other => {
+                                            let _ = _serde::de::MapAccess::next_value::<
+                                                _serde::de::IgnoredAny,
+                                            >(
+                                                &mut __map
+                                            )?;
+                                            continue;
+                                        }
+                                        _serde::__private229::de::TagContentOtherField::Tag => {
+                                            __rk = _serde::__private229::Some(
+                                                _serde::__private229::de::TagOrContentField::Tag,
+                                            );
+                                            break;
+                                        }
+                                        _serde::__private229::de::TagContentOtherField::Content => {
+                                            __rk = _serde::__private229::Some(_serde::__private229::de::TagOrContentField::Content);
+                                            break;
+                                        }
+                                    }
+                                }
+                                __rk
+                            } {
+                                _serde::__private229::Some(
+                                    _serde::__private229::de::TagOrContentField::Tag,
+                                ) => {
+                                    let __seed = __Seed { variant: _serde::de::MapAccess::next_value_seed(&mut __map, _serde::__private229::de::AdjacentlyTaggedEnumVariantSeed::<__Field> { enum_name: "DemoValueEnum", variants: VARIANTS, fields_enum: _serde::__private229::PhantomData })?, marker: _serde::__private229::PhantomData, lifetime: _serde::__private229::PhantomData };
+                                    let __deserializer =
+                                            _serde::__private229::de::ContentDeserializer::<
+                                                __A::Error,
+                                            >::new(
+                                                __content
+                                            );
+                                    let __ret = _serde::de::DeserializeSeed::deserialize(
+                                        __seed,
+                                        __deserializer,
+                                    )?;
+                                    match {
+                                        let mut __rk: _serde::__private229::Option<
+                                            _serde::__private229::de::TagOrContentField,
+                                        > = _serde::__private229::None;
+                                        while let _serde::__private229::Some(__k) = _serde::de::MapAccess::next_key_seed(&mut __map, _serde::__private229::de::TagContentOtherFieldVisitor { tag: "type", content: "data" })? {
+                                                match __k {
+                                                    _serde::__private229::de::TagContentOtherField::Other => {
+                                                        let _ = _serde::de::MapAccess::next_value::<_serde::de::IgnoredAny>(&mut __map)?;
+                                                        continue;
+                                                    }
+                                                    _serde::__private229::de::TagContentOtherField::Tag => {
+                                                        __rk = _serde::__private229::Some(_serde::__private229::de::TagOrContentField::Tag);
+                                                        break;
+                                                    }
+                                                    _serde::__private229::de::TagContentOtherField::Content => {
+                                                        __rk = _serde::__private229::Some(_serde::__private229::de::TagOrContentField::Content);
+                                                        break;
+                                                    }
+                                                }
+                                            }
+                                        __rk
+                                    } {
+                                        _serde::__private229::Some(
+                                            _serde::__private229::de::TagOrContentField::Tag,
+                                        ) => _serde::__private229::Err(
+                                            <__A::Error as _serde::de::Error>::duplicate_field(
+                                                "type",
+                                            ),
+                                        ),
+                                        _serde::__private229::Some(
+                                            _serde::__private229::de::TagOrContentField::Content,
+                                        ) => _serde::__private229::Err(
+                                            <__A::Error as _serde::de::Error>::duplicate_field(
+                                                "data",
+                                            ),
+                                        ),
+                                        _serde::__private229::None => {
+                                            _serde::__private229::Ok(__ret)
+                                        }
+                                    }
+                                }
+                                _serde::__private229::Some(
+                                    _serde::__private229::de::TagOrContentField::Content,
+                                ) => _serde::__private229::Err(
+                                    <__A::Error as _serde::de::Error>::duplicate_field("data"),
+                                ),
+                                _serde::__private229::None => _serde::__private229::Err(
+                                    <__A::Error as _serde::de::Error>::missing_field("type"),
+                                ),
+                            }
+                        }
+                        _serde::__private229::None => _serde::__private229::Err(
+                            <__A::Error as _serde::de::Error>::missing_field("type"),
+                        ),
+                    }
+                }
+                fn visit_seq<__A>(
+                    self,
+                    mut __seq: __A,
+                ) -> _serde::__private229::Result<Self::Value, __A::Error>
+                where
+                    __A: _serde::de::SeqAccess<'de>,
+                {
+                    match _serde::de::SeqAccess::next_element(&mut __seq) {
+                        _serde::__private229::Ok(_serde::__private229::Some(__variant)) => {
+                            match _serde::de::SeqAccess::next_element_seed(
+                                &mut __seq,
+                                __Seed {
+                                    variant: __variant,
+                                    marker: _serde::__private229::PhantomData,
+                                    lifetime: _serde::__private229::PhantomData,
+                                },
+                            ) {
+                                _serde::__private229::Ok(_serde::__private229::Some(__ret)) => {
+                                    _serde::__private229::Ok(__ret)
+                                }
+                                _serde::__private229::Ok(_serde::__private229::None) => {
+                                    _serde::__private229::Err(_serde::de::Error::invalid_length(
+                                        1, &self,
+                                    ))
+                                }
+                                _serde::__private229::Err(__err) => {
+                                    _serde::__private229::Err(__err)
+                                }
+                            }
+                        }
+                        _serde::__private229::Ok(_serde::__private229::None) => {
+                            _serde::__private229::Err(_serde::de::Error::invalid_length(0, &self))
+                        }
+                        _serde::__private229::Err(__err) => _serde::__private229::Err(__err),
+                    }
+                }
+            }
+            #[doc(hidden)]
+            const FIELDS: &'static [&'static str] = &["type", "data"];
+            _serde::Deserializer::deserialize_struct(
+                __deserializer,
+                "DemoValueEnum",
+                FIELDS,
+                __Visitor {
+                    marker: _serde::__private229::PhantomData::<DemoValueEnum>,
+                    lifetime: _serde::__private229::PhantomData,
+                },
+            )
+        }
+    }
+};
+
+#[doc(hidden)]
+#[allow(
+    non_upper_case_globals,
+    unused_attributes,
+    unused_qualifications,
+    clippy::absolute_paths
+)]
+const _: () = {
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
+    extern crate serde as _serde;
+    _serde::__require_serde_not_serde_core!();
+    #[automatically_derived]
+    impl _serde::Serialize for DemoInnerStruct {
+        fn serialize<__S>(
+            &self,
+            __serializer: __S,
+        ) -> _serde::__private229::Result<__S::Ok, __S::Error>
+        where
+            __S: _serde::Serializer,
+        {
+            let mut __serde_state = _serde::Serializer::serialize_struct(
+                __serializer,
+                "DemoInnerStruct",
+                false as usize + 1,
+            )?;
+            _serde::ser::SerializeStruct::serialize_field(
+                &mut __serde_state,
+                "enum_k",
+                &self.enum_k,
+            )?;
+            _serde::ser::SerializeStruct::end(__serde_state)
+        }
+    }
+};
+
+#[doc(hidden)]
+#[allow(
+    non_upper_case_globals,
+    unused_attributes,
+    unused_qualifications,
+    clippy::absolute_paths
+)]
+const _: () = {
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
+    extern crate serde as _serde;
+    _serde::__require_serde_not_serde_core!();
+    #[automatically_derived]
+    impl<'de> _serde::Deserialize<'de> for DemoInnerStruct {
+        fn deserialize<__D>(__deserializer: __D) -> _serde::__private229::Result<Self, __D::Error>
+        where
+            __D: _serde::Deserializer<'de>,
+        {
+            #[allow(non_camel_case_types)]
+            #[doc(hidden)]
+            enum __Field {
+                __field0,
+                __ignore,
+            }
+            #[doc(hidden)]
+            struct __FieldVisitor;
+            #[automatically_derived]
+            impl<'de> _serde::de::Visitor<'de> for __FieldVisitor {
+                type Value = __Field;
+                fn expecting(
+                    &self,
+                    __formatter: &mut _serde::__private229::Formatter<'_>,
+                ) -> _serde::__private229::fmt::Result {
+                    _serde::__private229::Formatter::write_str(__formatter, "field identifier")
+                }
+                fn visit_u64<__E>(
+                    self,
+                    __value: u64,
+                ) -> _serde::__private229::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        0u64 => _serde::__private229::Ok(__Field::__field0),
+                        _ => _serde::__private229::Ok(__Field::__ignore),
+                    }
+                }
+                fn visit_str<__E>(
+                    self,
+                    __value: &str,
+                ) -> _serde::__private229::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        "enum_k" => _serde::__private229::Ok(__Field::__field0),
+                        _ => _serde::__private229::Ok(__Field::__ignore),
+                    }
+                }
+                fn visit_bytes<__E>(
+                    self,
+                    __value: &[u8],
+                ) -> _serde::__private229::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        b"enum_k" => _serde::__private229::Ok(__Field::__field0),
+                        _ => _serde::__private229::Ok(__Field::__ignore),
+                    }
+                }
+            }
+            #[automatically_derived]
+            impl<'de> _serde::Deserialize<'de> for __Field {
+                #[inline]
+                fn deserialize<__D>(
+                    __deserializer: __D,
+                ) -> _serde::__private229::Result<Self, __D::Error>
+                where
+                    __D: _serde::Deserializer<'de>,
+                {
+                    _serde::Deserializer::deserialize_identifier(__deserializer, __FieldVisitor)
+                }
+            }
+            #[doc(hidden)]
+            struct __Visitor<'de> {
+                marker: _serde::__private229::PhantomData<DemoInnerStruct>,
+                lifetime: _serde::__private229::PhantomData<&'de ()>,
+            }
+            #[automatically_derived]
+            impl<'de> _serde::de::Visitor<'de> for __Visitor<'de> {
+                type Value = DemoInnerStruct;
+                fn expecting(
+                    &self,
+                    __formatter: &mut _serde::__private229::Formatter<'_>,
+                ) -> _serde::__private229::fmt::Result {
+                    _serde::__private229::Formatter::write_str(
+                        __formatter,
+                        "struct DemoInnerStruct",
+                    )
+                }
+                #[inline]
+                fn visit_seq<__A>(
+                    self,
+                    mut __seq: __A,
+                ) -> _serde::__private229::Result<Self::Value, __A::Error>
+                where
+                    __A: _serde::de::SeqAccess<'de>,
+                {
+                    let __field0 =
+                        match _serde::de::SeqAccess::next_element::<DemoEnum>(&mut __seq)? {
+                            _serde::__private229::Some(__value) => __value,
+                            _serde::__private229::None => {
+                                return _serde::__private229::Err(
+                                    _serde::de::Error::invalid_length(
+                                        0usize,
+                                        &"struct DemoInnerStruct with 1 element",
+                                    ),
+                                )
+                            }
+                        };
+                    _serde::__private229::Ok(DemoInnerStruct { enum_k: __field0 })
+                }
+                #[inline]
+                fn visit_map<__A>(
+                    self,
+                    mut __map: __A,
+                ) -> _serde::__private229::Result<Self::Value, __A::Error>
+                where
+                    __A: _serde::de::MapAccess<'de>,
+                {
+                    let mut __field0: _serde::__private229::Option<DemoEnum> =
+                        _serde::__private229::None;
+                    while let _serde::__private229::Some(__key) =
+                        _serde::de::MapAccess::next_key::<__Field>(&mut __map)?
+                    {
+                        match __key {
+                            __Field::__field0 => {
+                                if _serde::__private229::Option::is_some(&__field0) {
+                                    return _serde::__private229::Err(
+                                        <__A::Error as _serde::de::Error>::duplicate_field(
+                                            "enum_k",
+                                        ),
+                                    );
+                                }
+                                __field0 = _serde::__private229::Some(
+                                    _serde::de::MapAccess::next_value::<DemoEnum>(&mut __map)?,
+                                );
+                            }
+                            _ => {
+                                let _ = _serde::de::MapAccess::next_value::<_serde::de::IgnoredAny>(
+                                    &mut __map,
+                                )?;
+                            }
+                        }
+                    }
+                    let __field0 = match __field0 {
+                        _serde::__private229::Some(__field0) => __field0,
+                        _serde::__private229::None => {
+                            _serde::__private229::de::missing_field("enum_k")?
+                        }
+                    };
+                    _serde::__private229::Ok(DemoInnerStruct { enum_k: __field0 })
+                }
+            }
+            #[doc(hidden)]
+            const FIELDS: &'static [&'static str] = &["enum_k"];
+            _serde::Deserializer::deserialize_struct(
+                __deserializer,
+                "DemoInnerStruct",
+                FIELDS,
+                __Visitor {
+                    marker: _serde::__private229::PhantomData::<DemoInnerStruct>,
+                    lifetime: _serde::__private229::PhantomData,
+                },
+            )
+        }
+    }
+};
+
+#[doc(hidden)]
+#[allow(
+    non_upper_case_globals,
+    unused_attributes,
+    unused_qualifications,
+    clippy::absolute_paths
+)]
+const _: () = {
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
+    extern crate serde as _serde;
+    _serde::__require_serde_not_serde_core!();
+    #[automatically_derived]
+    impl _serde::Serialize for DemoStruct {
+        fn serialize<__S>(
+            &self,
+            __serializer: __S,
+        ) -> _serde::__private229::Result<__S::Ok, __S::Error>
+        where
+            __S: _serde::Serializer,
+        {
+            let mut __serde_state = _serde::Serializer::serialize_struct(
+                __serializer,
+                "DemoStruct",
+                false as usize + 1 + 1 + 1 + 1,
+            )?;
+            _serde::ser::SerializeStruct::serialize_field(
+                &mut __serde_state,
+                "enum_k",
+                &self.enum_k,
+            )?;
+            _serde::ser::SerializeStruct::serialize_field(
+                &mut __serde_state,
+                "inner_struct",
+                &self.inner_struct,
+            )?;
+            _serde::ser::SerializeStruct::serialize_field(
+                &mut __serde_state,
+                "array",
+                &self.array,
+            )?;
+            _serde::ser::SerializeStruct::serialize_field(
+                &mut __serde_state,
+                "enum_with_value",
+                &self.enum_with_value,
+            )?;
+            _serde::ser::SerializeStruct::end(__serde_state)
+        }
+    }
+};
+
+#[doc(hidden)]
+#[allow(
+    non_upper_case_globals,
+    unused_attributes,
+    unused_qualifications,
+    clippy::absolute_paths
+)]
+const _: () = {
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
+    extern crate serde as _serde;
+    _serde::__require_serde_not_serde_core!();
+    #[automatically_derived]
+    impl<'de> _serde::Deserialize<'de> for DemoStruct {
+        fn deserialize<__D>(__deserializer: __D) -> _serde::__private229::Result<Self, __D::Error>
+        where
+            __D: _serde::Deserializer<'de>,
+        {
+            #[allow(non_camel_case_types)]
+            #[doc(hidden)]
+            enum __Field {
+                __field0,
+                __field1,
+                __field2,
+                __field3,
+                __ignore,
+            }
+            #[doc(hidden)]
+            struct __FieldVisitor;
+            #[automatically_derived]
+            impl<'de> _serde::de::Visitor<'de> for __FieldVisitor {
+                type Value = __Field;
+                fn expecting(
+                    &self,
+                    __formatter: &mut _serde::__private229::Formatter<'_>,
+                ) -> _serde::__private229::fmt::Result {
+                    _serde::__private229::Formatter::write_str(__formatter, "field identifier")
+                }
+                fn visit_u64<__E>(
+                    self,
+                    __value: u64,
+                ) -> _serde::__private229::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        0u64 => _serde::__private229::Ok(__Field::__field0),
+                        1u64 => _serde::__private229::Ok(__Field::__field1),
+                        2u64 => _serde::__private229::Ok(__Field::__field2),
+                        3u64 => _serde::__private229::Ok(__Field::__field3),
+                        _ => _serde::__private229::Ok(__Field::__ignore),
+                    }
+                }
+                fn visit_str<__E>(
+                    self,
+                    __value: &str,
+                ) -> _serde::__private229::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        "enum_k" => _serde::__private229::Ok(__Field::__field0),
+                        "inner_struct" => _serde::__private229::Ok(__Field::__field1),
+                        "array" => _serde::__private229::Ok(__Field::__field2),
+                        "enum_with_value" => _serde::__private229::Ok(__Field::__field3),
+                        _ => _serde::__private229::Ok(__Field::__ignore),
+                    }
+                }
+                fn visit_bytes<__E>(
+                    self,
+                    __value: &[u8],
+                ) -> _serde::__private229::Result<Self::Value, __E>
+                where
+                    __E: _serde::de::Error,
+                {
+                    match __value {
+                        b"enum_k" => _serde::__private229::Ok(__Field::__field0),
+                        b"inner_struct" => _serde::__private229::Ok(__Field::__field1),
+                        b"array" => _serde::__private229::Ok(__Field::__field2),
+                        b"enum_with_value" => _serde::__private229::Ok(__Field::__field3),
+                        _ => _serde::__private229::Ok(__Field::__ignore),
+                    }
+                }
+            }
+            #[automatically_derived]
+            impl<'de> _serde::Deserialize<'de> for __Field {
+                #[inline]
+                fn deserialize<__D>(
+                    __deserializer: __D,
+                ) -> _serde::__private229::Result<Self, __D::Error>
+                where
+                    __D: _serde::Deserializer<'de>,
+                {
+                    _serde::Deserializer::deserialize_identifier(__deserializer, __FieldVisitor)
+                }
+            }
+            #[doc(hidden)]
+            struct __Visitor<'de> {
+                marker: _serde::__private229::PhantomData<DemoStruct>,
+                lifetime: _serde::__private229::PhantomData<&'de ()>,
+            }
+            #[automatically_derived]
+            impl<'de> _serde::de::Visitor<'de> for __Visitor<'de> {
+                type Value = DemoStruct;
+                fn expecting(
+                    &self,
+                    __formatter: &mut _serde::__private229::Formatter<'_>,
+                ) -> _serde::__private229::fmt::Result {
+                    _serde::__private229::Formatter::write_str(__formatter, "struct DemoStruct")
+                }
+                #[inline]
+                fn visit_seq<__A>(
+                    self,
+                    mut __seq: __A,
+                ) -> _serde::__private229::Result<Self::Value, __A::Error>
+                where
+                    __A: _serde::de::SeqAccess<'de>,
+                {
+                    let __field0 =
+                        match _serde::de::SeqAccess::next_element::<DemoEnum>(&mut __seq)? {
+                            _serde::__private229::Some(__value) => __value,
+                            _serde::__private229::None => {
+                                return _serde::__private229::Err(
+                                    _serde::de::Error::invalid_length(
+                                        0usize,
+                                        &"struct DemoStruct with 4 elements",
+                                    ),
+                                )
+                            }
+                        };
+                    let __field1 =
+                        match _serde::de::SeqAccess::next_element::<DemoInnerStruct>(&mut __seq)? {
+                            _serde::__private229::Some(__value) => __value,
+                            _serde::__private229::None => {
+                                return _serde::__private229::Err(
+                                    _serde::de::Error::invalid_length(
+                                        1usize,
+                                        &"struct DemoStruct with 4 elements",
+                                    ),
+                                )
+                            }
+                        };
+                    let __field2 =
+                        match _serde::de::SeqAccess::next_element::<Vec<DemoEnum>>(&mut __seq)? {
+                            _serde::__private229::Some(__value) => __value,
+                            _serde::__private229::None => {
+                                return _serde::__private229::Err(
+                                    _serde::de::Error::invalid_length(
+                                        2usize,
+                                        &"struct DemoStruct with 4 elements",
+                                    ),
+                                )
+                            }
+                        };
+                    let __field3 = match _serde::de::SeqAccess::next_element::<Vec<DemoValueEnum>>(
+                        &mut __seq,
+                    )? {
+                        _serde::__private229::Some(__value) => __value,
+                        _serde::__private229::None => {
+                            return _serde::__private229::Err(_serde::de::Error::invalid_length(
+                                3usize,
+                                &"struct DemoStruct with 4 elements",
+                            ))
+                        }
+                    };
+                    _serde::__private229::Ok(DemoStruct {
+                        enum_k: __field0,
+                        inner_struct: __field1,
+                        array: __field2,
+                        enum_with_value: __field3,
+                    })
+                }
+                #[inline]
+                fn visit_map<__A>(
+                    self,
+                    mut __map: __A,
+                ) -> _serde::__private229::Result<Self::Value, __A::Error>
+                where
+                    __A: _serde::de::MapAccess<'de>,
+                {
+                    let mut __field0: _serde::__private229::Option<DemoEnum> =
+                        _serde::__private229::None;
+                    let mut __field1: _serde::__private229::Option<DemoInnerStruct> =
+                        _serde::__private229::None;
+                    let mut __field2: _serde::__private229::Option<Vec<DemoEnum>> =
+                        _serde::__private229::None;
+                    let mut __field3: _serde::__private229::Option<Vec<DemoValueEnum>> =
+                        _serde::__private229::None;
+                    while let _serde::__private229::Some(__key) =
+                        _serde::de::MapAccess::next_key::<__Field>(&mut __map)?
+                    {
+                        match __key {
+                            __Field::__field0 => {
+                                if _serde::__private229::Option::is_some(&__field0) {
+                                    return _serde::__private229::Err(
+                                        <__A::Error as _serde::de::Error>::duplicate_field(
+                                            "enum_k",
+                                        ),
+                                    );
+                                }
+                                __field0 = _serde::__private229::Some(
+                                    _serde::de::MapAccess::next_value::<DemoEnum>(&mut __map)?,
+                                );
+                            }
+                            __Field::__field1 => {
+                                if _serde::__private229::Option::is_some(&__field1) {
+                                    return _serde::__private229::Err(
+                                        <__A::Error as _serde::de::Error>::duplicate_field(
+                                            "inner_struct",
+                                        ),
+                                    );
+                                }
+                                __field1 = _serde::__private229::Some(
+                                    _serde::de::MapAccess::next_value::<DemoInnerStruct>(
+                                        &mut __map,
+                                    )?,
+                                );
+                            }
+                            __Field::__field2 => {
+                                if _serde::__private229::Option::is_some(&__field2) {
+                                    return _serde::__private229::Err(
+                                        <__A::Error as _serde::de::Error>::duplicate_field("array"),
+                                    );
+                                }
+                                __field2 = _serde::__private229::Some(
+                                    _serde::de::MapAccess::next_value::<Vec<DemoEnum>>(&mut __map)?,
+                                );
+                            }
+                            __Field::__field3 => {
+                                if _serde::__private229::Option::is_some(&__field3) {
+                                    return _serde::__private229::Err(
+                                        <__A::Error as _serde::de::Error>::duplicate_field(
+                                            "enum_with_value",
+                                        ),
+                                    );
+                                }
+                                __field3 = _serde::__private229::Some(
+                                    _serde::de::MapAccess::next_value::<Vec<DemoValueEnum>>(
+                                        &mut __map,
+                                    )?,
+                                );
+                            }
+                            _ => {
+                                let _ = _serde::de::MapAccess::next_value::<_serde::de::IgnoredAny>(
+                                    &mut __map,
+                                )?;
+                            }
+                        }
+                    }
+                    let __field0 = match __field0 {
+                        _serde::__private229::Some(__field0) => __field0,
+                        _serde::__private229::None => {
+                            _serde::__private229::de::missing_field("enum_k")?
+                        }
+                    };
+                    let __field1 = match __field1 {
+                        _serde::__private229::Some(__field1) => __field1,
+                        _serde::__private229::None => {
+                            _serde::__private229::de::missing_field("inner_struct")?
+                        }
+                    };
+                    let __field2 = match __field2 {
+                        _serde::__private229::Some(__field2) => __field2,
+                        _serde::__private229::None => {
+                            _serde::__private229::de::missing_field("array")?
+                        }
+                    };
+                    let __field3 = match __field3 {
+                        _serde::__private229::Some(__field3) => __field3,
+                        _serde::__private229::None => {
+                            _serde::__private229::de::missing_field("enum_with_value")?
+                        }
+                    };
+                    _serde::__private229::Ok(DemoStruct {
+                        enum_k: __field0,
+                        inner_struct: __field1,
+                        array: __field2,
+                        enum_with_value: __field3,
+                    })
+                }
+            }
+            #[doc(hidden)]
+            const FIELDS: &'static [&'static str] =
+                &["enum_k", "inner_struct", "array", "enum_with_value"];
+            _serde::Deserializer::deserialize_struct(
+                __deserializer,
+                "DemoStruct",
+                FIELDS,
+                __Visitor {
+                    marker: _serde::__private229::PhantomData::<DemoStruct>,
+                    lifetime: _serde::__private229::PhantomData,
+                },
+            )
+        }
+    }
+};


### PR DESCRIPTION
1. add `Skipper` help struct, manually skip whole object/array/value.
2. add serde compatibility support
     1. `JsonValueSink` serialize serde `Serialize` type into `WriterJsonSerializer`
     2. `JsonValueSource` deserialize part of data into serde `Deserialize` type from `ReaderJsonParser`